### PR TITLE
*Fixes problems with Julia 0.4 breaking changes - tupples, dicts,

### DIFF
--- a/src/NIDAQ.jl
+++ b/src/NIDAQ.jl
@@ -41,12 +41,12 @@ export Bool32
 
 try
   global ver
-  major = Uint32[0]
-  ccall((:DAQmxGetSysNIDAQMajorVersion,NIDAQmx),Int32,(Ptr{Uint32},),major)
-  minor = Uint32[0]
-  ccall((:DAQmxGetSysNIDAQMinorVersion,NIDAQmx),Int32,(Ptr{Uint32},),minor)
-  update = Uint32[0]
-  ccall((:DAQmxGetSysNIDAQUpdateVersion,NIDAQmx),Int32,(Ptr{Uint32},),update)
+  major = UInt32[0]
+  ccall((:DAQmxGetSysNIDAQMajorVersion,NIDAQmx),Int32,(Ptr{UInt32},),major)
+  minor = UInt32[0]
+  ccall((:DAQmxGetSysNIDAQMinorVersion,NIDAQmx),Int32,(Ptr{UInt32},),minor)
+  update = UInt32[0]
+  ccall((:DAQmxGetSysNIDAQUpdateVersion,NIDAQmx),Int32,(Ptr{UInt32},),update)
   ver = "$(major[1]).$(minor[1]).$(update[1])"
 catch
   error("can not determine NIDAQmx version.")
@@ -59,8 +59,8 @@ catch
   error("NIDAQmx version $ver is not supported.")
 end
 
-unsigned_constants = (Uint64=>Symbol)[]
-signed_constants = (Int64=>Symbol)[]
+unsigned_constants = Dict{UInt64,Symbol}()
+signed_constants = Dict{Int64,Symbol}()
 
 for sym in names(NIDAQ,true)
     isdefined(sym) || continue
@@ -69,7 +69,7 @@ for sym in names(NIDAQ,true)
     sym_str = sym_str[6:end]
     sym_str[1]=='_' && (sym_str = sym_str[2:end])
     if @eval typeof($sym) <: Unsigned
-        @eval $(symbol(sym_str)) = uint32($sym)
+        @eval $(symbol(sym_str)) = UInt32($sym)
         unsigned_constants[eval(:($sym))] = symbol(sym_str)
     elseif @eval typeof($sym) <: Signed
         sym_str[1:min(end,4)]=="Val_" || continue
@@ -81,9 +81,9 @@ for sym in names(NIDAQ,true)
 end
 
 function catch_error(code::Int32, extra::ASCIIString=""; err_fcn=error)
-    sz = DAQmxGetErrorString(code, convert(Ptr{Uint8},C_NULL), convert(Uint32,0))
-    data = zeros(Uint8,sz)
-    ret = DAQmxGetErrorString(code, convert(Ptr{Uint8},data), convert(Uint32,sz))
+    sz = DAQmxGetErrorString(code, convert(Ptr{UInt8},C_NULL), convert(UInt32,0))
+    data = zeros(UInt8,sz)
+    ret = DAQmxGetErrorString(code, pointer(data), convert(UInt32,sz))
     ret>0 && warn("DAQmxGetErrorString error $ret")
     ret<0 && err_fcn("DAQmxGetErrorString error $ret")
     data = chop(convert(ASCIIString, data))

--- a/src/analog.jl
+++ b/src/analog.jl
@@ -1,7 +1,7 @@
-analog_input_configs = {
+analog_input_configs = Dict{Any,Any}(
     "referenced single-ended" => Val_RSE,
     "non-referenced single-ended" => Val_NRSE,
-    "differential" => Val_Diff }
+    "differential" => Val_Diff )
 
 function analog_input(channel::ASCIIString; terminal_config="differential", range=nothing)
     t = AITask()
@@ -16,12 +16,12 @@ function analog_input(t::AITask, channel::ASCIIString;
         range=float(analog_input_ranges(device)[end,:])
     end
     catch_error( CreateAIVoltageChan(t.th,
-            convert(Ptr{Uint8},channel),
-            convert(Ptr{Uint8},""),
+            pointer(channel),
+            pointer(""),
             analog_input_configs[terminal_config],
             range[1], range[2],
             Val_Volts,
-            convert(Ptr{Uint8},C_NULL)) )
+            convert(Ptr{UInt8},C_NULL)) )
     nothing
 end
 
@@ -37,20 +37,20 @@ function analog_output(t::AOTask, channel::ASCIIString; range=nothing)
         range=float(analog_output_ranges(device)[end,:])
     end
     catch_error( CreateAOVoltageChan(t.th,
-            convert(Ptr{Uint8},channel),
-            convert(Ptr{Uint8},""),
+            pointer(channel),
+            pointer(""),
             range[1], range[2],
             Val_Volts,
-            convert(Ptr{Uint8},C_NULL)) )
+            convert(Ptr{UInt8},C_NULL)) )
     nothing
 end
 
-read_analog_cfunctions = {
+read_analog_cfunctions = Dict{Any,Any}(
     (Float64 => ReadAnalogF64),
     (Int16 => ReadBinaryI16),
     (Int32 => ReadBinaryI32),
-    (Uint16 => ReadBinaryU16),
-    (Uint32 => ReadBinaryU32) }
+    (UInt16 => ReadBinaryU16),
+    (UInt32 => ReadBinaryU32) )
 
 function read(t::AITask, precision::DataType, num_samples_per_chan::Integer = -1)
     num_channels = getproperties(t)["NumChans"][1]
@@ -61,9 +61,9 @@ function read(t::AITask, precision::DataType, num_samples_per_chan::Integer = -1
         convert(Int32,num_samples_per_chan),
         1.0,
         reinterpret(Bool32,Val_GroupByChannel),
-        convert(Ptr{precision},data),
-        convert(Uint32,num_samples_per_chan*num_channels),
-        convert(Ptr{Int32},num_samples_per_chan_read),
+        pointer(data),
+        convert(UInt32,num_samples_per_chan*num_channels),
+        pointer(num_samples_per_chan_read),
         reinterpret(Ptr{Bool32},C_NULL)) )
     data = data[1:num_samples_per_chan_read[1]*num_channels]
     num_channels==1 ? data : reshape(data, (num_samples_per_chan, convert(Int64,num_channels)))
@@ -73,19 +73,19 @@ for (cfunction, types) in (
         (WriteAnalogF64, Float64),
         (WriteBinaryI16, Int16),
         (WriteBinaryI32, Int32),
-        (WriteBinaryU16, Uint16),
-        (WriteBinaryU32, Uint32))
+        (WriteBinaryU16, UInt16),
+        (WriteBinaryU32, UInt32))
     @eval function write(t::AOTask, data::Matrix{$types})
         num_samples_per_chan::Int32 = size(data, 1)
         data = reshape(data, length(data))
         num_samples_per_chan_written = Int32[0]
         catch_error( $cfunction(t.th,
             num_samples_per_chan,
-            reinterpret(Bool32, uint32(false)),
+            reinterpret(Bool32, UInt32(false)),
             1.0,
             reinterpret(Bool32,Val_GroupByChannel),
-            convert(Ptr{$types},data),
-            convert(Ptr{Int32},num_samples_per_chan_written),
+            pointer(data),
+            pointer(num_samples_per_chan_written),
             reinterpret(Ptr{Bool32},C_NULL)) )
         num_samples_per_chan_written[1]
     end

--- a/src/constants_V14.0.0.jl
+++ b/src/constants_V14.0.0.jl
@@ -3411,10 +3411,10 @@ const DAQmxWarningPALTransferOverread = 50411
 const DAQmxWarningPALDispatcherAlreadyExported = 50500
 const DAQmxWarningPALSyncAbandoned = 50551
 
-typealias int8 Uint8
+typealias int8 UInt8
 typealias uInt8 Cuchar
 typealias int16 Int16
-typealias uInt16 Uint16
+typealias uInt16 UInt16
 typealias int32 Clong
 typealias uInt32 Culong
 typealias float32 Cfloat

--- a/src/constants_V14.1.0.jl
+++ b/src/constants_V14.1.0.jl
@@ -3429,12 +3429,12 @@ const DAQmxWarningPALTransferOverread = 50411
 const DAQmxWarningPALDispatcherAlreadyExported = 50500
 const DAQmxWarningPALSyncAbandoned = 50551
 
-typealias int8 Uint8
+typealias int8 UInt8
 typealias uInt8 Cuchar
 typealias int16 Int16
-typealias uInt16 Uint16
+typealias uInt16 UInt16
 typealias int32 Cint
-typealias uInt32 Uint32
+typealias uInt32 UInt32
 typealias float32 Cfloat
 typealias float64 Cdouble
 typealias int64 Clonglong

--- a/src/constants_V9.6.0.jl
+++ b/src/constants_V9.6.0.jl
@@ -3333,10 +3333,10 @@ const DAQmxWarningPALTransferOverread = 50411
 const DAQmxWarningPALDispatcherAlreadyExported = 50500
 const DAQmxWarningPALSyncAbandoned = 50551
 
-typealias int8 Uint8
+typealias int8 UInt8
 typealias uInt8 Cuchar
 typealias int16 Int16
-typealias uInt16 Uint16
+typealias uInt16 UInt16
 typealias int32 Clong
 typealias uInt32 Culong
 typealias float32 Cfloat

--- a/src/counter.jl
+++ b/src/counter.jl
@@ -1,34 +1,34 @@
 function count_edges(channel::ASCIIString;
-        edge::String="rising", initial_count::Integer=0, direction::String="up")
+        edge::AbstractString="rising", initial_count::Integer=0, direction::AbstractString="up")
     t = CITask()
-    if edge ∉ {"rising", "falling"}
+    if edge ∉ ["rising", "falling"]
         error("edge must either be \"rising\" or \"falling\"")
     end
-    if direction ∉ {"up", "down"}
+    if direction ∉ ["up", "down"]
         error("direction must either be \"up\" or \"down\"")
     end
     catch_error( CreateCICountEdgesChan(t.th,
-        convert(Ptr{Uint8},channel),
-        convert(Ptr{Uint8},""),
+        convert(Ptr{UInt8},channel),
+        convert(Ptr{UInt8},""),
         edge == "rising" ? Val_Rising : Val_Falling,
-        uint32(initial_count),
+        UInt32(initial_count),
         direction == "up" ? Val_CountUp : Val_CountDown) )
     t
 end
 
 # broken
-function measure_duty_cycle(channel::ASCIIString;  units::String="seconds")
+function measure_duty_cycle(channel::ASCIIString;  units::AbstractString="seconds")
     t = CITask()
     if units == "seconds"
         ret = CreateCIPulseChanTime(t.th,
-                convert(Ptr{Uint8},channel), convert(Ptr{Uint8},""),
+                convert(Ptr{UInt8},channel), convert(Ptr{UInt8},""),
                 2.0, 1000.0,
                 Val_Seconds)
     elseif units == "ticks"
         ret = CreateCIPulseChanTicks(t.th,
-                convert(Ptr{Uint8},channel),
-                convert(Ptr{Uint8},""),
-                convert(Ptr{Uint8},""),
+                convert(Ptr{UInt8},channel),
+                convert(Ptr{UInt8},""),
+                convert(Ptr{UInt8},""),
                 2.0, 1000.0)
     else
         error("units must either be \"seconds\" or \"ticks\"")
@@ -40,40 +40,40 @@ end
 function quadrature_input(channel::ASCIIString;  z_enable::Bool=true)
     t = CITask()
     ret = CreateCIAngEncoderChan(t.th,
-            convert(Ptr{Uint8},channel),
-            convert(Ptr{Uint8},""),
+            convert(Ptr{UInt8},channel),
+            convert(Ptr{UInt8},""),
             Val_X4,
-            reinterpret(Bool32, uint32(z_enable)),
+            reinterpret(Bool32, UInt32(z_enable)),
             0.0,
             Val_AHighBHigh,
             Val_Ticks,
-            uint32(1), 0.0,
-            convert(Ptr{Uint8},""))
+            UInt32(1), 0.0,
+            convert(Ptr{UInt8},""))
     ret>0 && warn(error(ret))
     ret<0 && error(error(ret))
     t
 end
 
 function line_to_line(channel::ASCIIString;
-        units::String="seconds", edge1::String="rising", edge2::String="rising")
+        units::AbstractString="seconds", edge1::AbstractString="rising", edge2::AbstractString="rising")
     t = CITask()
-    if units ∉ {"seconds", "ticks"}
+    if units ∉ ["seconds", "ticks"]
         error("units must either be \"seconds\" or \"ticks\"")
     end
-    if edge1 ∉ {"rising", "falling"}
+    if edge1 ∉ ["rising", "falling"]
         error("edge1 must either be \"rising\" or \"falling\"")
     end
-    if edge2 ∉ {"rising", "falling"}
+    if edge2 ∉ ["rising", "falling"]
         error("edge2 must either be \"rising\" or \"falling\"")
     end
     catch_error( CreateCITwoEdgeSepChan(t.th,
-            convert(Ptr{Uint8},channel),
-            convert(Ptr{Uint8},""),
-            1.0, 1000.0, 
+            convert(Ptr{UInt8},channel),
+            convert(Ptr{UInt8},""),
+            1.0, 1000.0,
             units == "seconds" ? Val_Seconds : Val_Ticks,
             edge1 == "rising" ? Val_Rising : Val_Falling,
             edge2 == "rising" ? Val_Rising : Val_Falling,
-            convert(Ptr{Uint8},"")) )
+            convert(Ptr{UInt8},"")) )
     t
 end
 
@@ -81,8 +81,8 @@ function generate_pulses{T<:Number}(channel::ASCIIString, low::T=2, high::T=2; d
     t = COTask()
     if T<:FloatingPoint
         ret = CreateCOPulseChanTime(t.th,
-                convert(Ptr{Uint8},channel),
-                convert(Ptr{Uint8},""),
+                pointer(channel),
+                pointer(""),
                 Val_Seconds,
                 Val_Low,
                 convert(Float64,delay),
@@ -90,9 +90,9 @@ function generate_pulses{T<:Number}(channel::ASCIIString, low::T=2, high::T=2; d
                 convert(Float64,high))
     elseif T<:Integer
         ret = CreateCOPulseChanTicks(t.th,
-                convert(Ptr{Uint8},channel),
-                convert(Ptr{Uint8},""),
-                convert(Ptr{Uint8},""),
+                pointer(channel),
+                pointer(""),
+                pointer(""),
                 Val_Low,
                 convert(Int32,delay),
                 convert(Int32,low),
@@ -109,7 +109,7 @@ function read(t::CITask, channel::ASCIIString, num_samples::Integer = -1)
 
     #function read_counter_scalar(precision::DataType, cfunction::Function)
     #    data = precision[0]
-    #    ret = cfunction(t, 1.0, convert(Ptr{precision},data), convert(Ptr{Uint32},C_NULL))
+    #    ret = cfunction(t, 1.0, convert(Ptr{precision},data), convert(Ptr{UInt32},C_NULL))
     #    ret>0 && warn("NIDAQmx: $ret")
     #    ret<0 && error("NIDAQmx: $ret")
     #    data
@@ -119,11 +119,11 @@ function read(t::CITask, channel::ASCIIString, num_samples::Integer = -1)
         num_samples_read = Int32[0]
         data = Array(precision, num_samples)
         catch_error( cfunction(t.th,
-            convert(Int32,num_samples),
+            pointer(num_samples),
             1.0,
-            convert(Ptr{precision},data),
-            convert(Uint32,num_samples),
-            convert(Ptr{Int32},num_samples_read),
+            pointer(data),
+            convert(UInt32,num_samples),
+            pointer(num_samples_read),
             reinterpret(Ptr{Bool32},C_NULL)) )
         data = data[1:num_samples_read[1]]
         reshape(data, (num_samples, div(length(data),num_samples)))
@@ -137,10 +137,10 @@ function read(t::CITask, channel::ASCIIString, num_samples::Integer = -1)
             convert(Int32,num_samples),
             1.0,
             Val_GroupByChannel,
-            convert(Ptr{Float64},high),
-            convert(Ptr{Float64},low),
-            convert(Uint32,num_samples),
-            convert(Ptr{Int32},num_samples_read),
+            pointer(high),
+            pointer(low),
+            convert(UInt32,num_samples),
+            pointer(num_samples_read),
             reinterpret(Ptr{Bool32},C_NULL)) )
         high = high[1:num_samples_read[1]]
         low = low[1:num_samples_read[1]]
@@ -150,21 +150,21 @@ function read(t::CITask, channel::ASCIIString, num_samples::Integer = -1)
 
     tmp = channel_type(t.th, channel)
     if tmp[2] == Val_CountEdges
-        data = read_counter_vector(Uint32, ReadCounterU32)
+        data = read_counter_vector(UInt32, ReadCounterU32)
     elseif tmp[2] == Val_PulseTime
         data = read_counter_2vectors(Float64, ReadCtrTime)
     elseif tmp[2] == Val_PulseTicks
-        data = read_counter_2vectors(Uint32, ReadCtrTicks)
+        data = read_counter_2vectors(UInt32, ReadCtrTicks)
     elseif tmp[2] == Val_Position_AngEncoder
-        data = read_counter_vector(Uint32, ReadCounterU32)
+        data = read_counter_vector(UInt32, ReadCounterU32)
     elseif tmp[2] == Val_TwoEdgeSep  # might be broken
         val = Cint[0]
         catch_error( GetCITwoEdgeSepUnits(t.th,
-                convert(Ptr{Uint8},channel),
-                convert(Ptr{Int32},val)) )
+                pointer(channel),
+                pointer(val)) )
         if val[1] == Val_Ticks
-            data = read_counter_vector(Uint32, ReadCounterU32)
-            #data = read_counter_scalar(Uint32, ReadCounterScalarU32)
+            data = read_counter_vector(UInt32, ReadCounterU32)
+            #data = read_counter_scalar(UInt32, ReadCounterScalarU32)
         elseif val[1] == Val_Seconds
             data = read_counter_vector(Float64, ReadCounterF64)
             #data = read_counter_scalar(Float64, ReadCounterScalarF64)

--- a/src/digital.jl
+++ b/src/digital.jl
@@ -8,17 +8,17 @@ for (cfunction, jfunction, ntask) in (
     end
     @eval function $jfunction(t::$ntask, channel::ASCIIString)
         catch_error( $cfunction(t.th,
-                convert(Ptr{Uint8},channel),
-                convert(Ptr{Uint8},""),
+                pointer(channel),
+                pointer(""),
                 Val_ChanPerLine) )
         nothing
     end
 end
 
-read_digital_cfunctions = {
-    (Uint8 => ReadDigitalU8),
-    (Uint16 => ReadDigitalU16),
-    (Uint32 => ReadDigitalU32) }
+read_digital_cfunctions = Dict{Any,Any}(
+    (UInt8 => ReadDigitalU8),
+    (UInt16 => ReadDigitalU16),
+    (UInt32 => ReadDigitalU32) )
 
 function read(t::DITask, precision::DataType, num_samples_per_chan::Integer = -1)
     num_channels = getproperties(t)["NumChans"][1]
@@ -29,32 +29,32 @@ function read(t::DITask, precision::DataType, num_samples_per_chan::Integer = -1
         convert(Int32,num_samples_per_chan),
         1.0,
         reinterpret(Bool32,Val_GroupByChannel),
-        convert(Ptr{precision},data),
-        convert(Uint32,num_samples_per_chan*num_channels),
-        convert(Ptr{Int32},num_samples_per_chan_read),
+        pointer(data),
+        convert(UInt32,num_samples_per_chan*num_channels),
+        pointer(num_samples_per_chan_read),
         reinterpret(Ptr{Bool32},C_NULL)) )
     data = data[1:num_samples_per_chan_read[1]*num_channels]
     num_channels==1 ? data : reshape(data, (num_samples_per_chan, convert(Int64,num_channels)))
-end 
-    
+end
+
 for (cfunction, types) in (
-        (WriteDigitalU8,  Uint8),
-        (WriteDigitalU16, Uint16),
-        (WriteDigitalU32, Uint32))
+        (WriteDigitalU8,  UInt8),
+        (WriteDigitalU16, UInt16),
+        (WriteDigitalU32, UInt32))
     @eval function write(t::DOTask, data::Matrix{$types})
         num_samples_per_chan::Int32 = size(data, 1)
         data = reshape(data, length(data))
         num_samples_per_chan_written = Int32[0]
         catch_error( $cfunction(t.th,
             num_samples_per_chan,
-            reinterpret(Bool32,uint32(false)),
+            reinterpret(Bool32,UInt32(false)),
             1.0,
             reinterpret(Bool32,Val_GroupByChannel),
-            convert(Ptr{$types},data),
-            convert(Ptr{Int32},num_samples_per_chan_written),
+            pointer(data),
+            pointer(num_samples_per_chan_written),
             reinterpret(Ptr{Bool32},C_NULL)) )
         num_samples_per_chan_written[1]
     end
-    @eval write(t::DOTask, data::Vector{$types}) = 
+    @eval write(t::DOTask, data::Vector{$types}) =
         write(t, reshape(data, (length(data),1)))
-end     
+end

--- a/src/functions_V14.0.0.jl
+++ b/src/functions_V14.0.0.jl
@@ -2,16 +2,16 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function DAQmxLoadTask(taskName::Ptr{Uint8},taskHandle::Ptr{TaskHandle})
-    ccall((:DAQmxLoadTask,NIDAQmx),int32,(Ptr{Uint8},Ptr{TaskHandle}),taskName,taskHandle)
+function DAQmxLoadTask(taskName::Ptr{UInt8},taskHandle::Ptr{TaskHandle})
+    ccall((:DAQmxLoadTask,NIDAQmx),int32,(Ptr{UInt8},Ptr{TaskHandle}),taskName,taskHandle)
 end
 
-function DAQmxCreateTask(taskName::Ptr{Uint8},taskHandle::Ptr{TaskHandle})
-    ccall((:DAQmxCreateTask,NIDAQmx),int32,(Ptr{Uint8},Ptr{TaskHandle}),taskName,taskHandle)
+function DAQmxCreateTask(taskName::Ptr{UInt8},taskHandle::Ptr{TaskHandle})
+    ccall((:DAQmxCreateTask,NIDAQmx),int32,(Ptr{UInt8},Ptr{TaskHandle}),taskName,taskHandle)
 end
 
-function DAQmxAddGlobalChansToTask(taskHandle::TaskHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAddGlobalChansToTask,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channelNames)
+function DAQmxAddGlobalChansToTask(taskHandle::TaskHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAddGlobalChansToTask,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channelNames)
 end
 
 function DAQmxStartTask(taskHandle::TaskHandle)
@@ -38,12 +38,12 @@ function DAQmxTaskControl(taskHandle::TaskHandle,action::int32)
     ccall((:DAQmxTaskControl,NIDAQmx),int32,(TaskHandle,int32),taskHandle,action)
 end
 
-function DAQmxGetNthTaskChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{Uint8},bufferSize::int32)
-    ccall((:DAQmxGetNthTaskChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{Uint8},int32),taskHandle,index,buffer,bufferSize)
+function DAQmxGetNthTaskChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{UInt8},bufferSize::int32)
+    ccall((:DAQmxGetNthTaskChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{UInt8},int32),taskHandle,index,buffer,bufferSize)
 end
 
-function DAQmxGetNthTaskDevice(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{Uint8},bufferSize::int32)
-    ccall((:DAQmxGetNthTaskDevice,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{Uint8},int32),taskHandle,index,buffer,bufferSize)
+function DAQmxGetNthTaskDevice(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{UInt8},bufferSize::int32)
+    ccall((:DAQmxGetNthTaskDevice,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{UInt8},int32),taskHandle,index,buffer,bufferSize)
 end
 
 function DAQmxRegisterEveryNSamplesEvent(task::TaskHandle,everyNsamplesEventType::int32,nSamples::uInt32,options::uInt32,callbackFunction::DAQmxEveryNSamplesEventCallbackPtr,callbackData::Ptr{Void})
@@ -58,388 +58,388 @@ function DAQmxRegisterSignalEvent(task::TaskHandle,signalID::int32,options::uInt
     ccall((:DAQmxRegisterSignalEvent,NIDAQmx),int32,(TaskHandle,int32,uInt32,DAQmxSignalEventCallbackPtr,Ptr{Void}),task,signalID,options,callbackFunction,callbackData)
 end
 
-function DAQmxCreateAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
+function DAQmxCreateAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
 end
 
-function DAQmxCreateAIVoltageRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVoltageRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAIVoltageRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVoltageRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAICurrentRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAICurrentRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
+function DAQmxCreateAICurrentRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAICurrentRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
 end
 
-function DAQmxCreateAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,thermocoupleType::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{Uint8})
-    ccall((:DAQmxCreateAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thermocoupleType,cjcSource,cjcVal,cjcChannel)
+function DAQmxCreateAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,thermocoupleType::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{UInt8})
+    ccall((:DAQmxCreateAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thermocoupleType,cjcSource,cjcVal,cjcChannel)
 end
 
-function DAQmxCreateAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,rtdType::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,r0::float64)
-    ccall((:DAQmxCreateAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,rtdType,resistanceConfig,currentExcitSource,currentExcitVal,r0)
+function DAQmxCreateAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,rtdType::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,r0::float64)
+    ccall((:DAQmxCreateAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,rtdType,resistanceConfig,currentExcitSource,currentExcitVal,r0)
 end
 
-function DAQmxCreateAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,a::float64,b::float64,c::float64)
-    ccall((:DAQmxCreateAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,a,b,c)
+function DAQmxCreateAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,a::float64,b::float64,c::float64)
+    ccall((:DAQmxCreateAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,a,b,c)
 end
 
-function DAQmxCreateAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,a::float64,b::float64,c::float64,r1::float64)
-    ccall((:DAQmxCreateAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,a,b,c,r1)
+function DAQmxCreateAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,a::float64,b::float64,c::float64,r1::float64)
+    ccall((:DAQmxCreateAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,a,b,c,r1)
 end
 
-function DAQmxCreateAIFreqVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,thresholdLevel::float64,hysteresis::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIFreqVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thresholdLevel,hysteresis,customScaleName)
+function DAQmxCreateAIFreqVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,thresholdLevel::float64,hysteresis::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIFreqVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thresholdLevel,hysteresis,customScaleName)
 end
 
-function DAQmxCreateAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,initialBridgeVoltage::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,initialBridgeVoltage,nominalGageResistance,poissonRatio,leadWireResistance,customScaleName)
+function DAQmxCreateAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,initialBridgeVoltage::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,initialBridgeVoltage,nominalGageResistance,poissonRatio,leadWireResistance,customScaleName)
 end
 
-function DAQmxCreateAIRosetteStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,rosetteType::int32,gageOrientation::float64,rosetteMeasTypes::Ptr{int32},numRosetteMeasTypes::uInt32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64)
-    ccall((:DAQmxCreateAIRosetteStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,Ptr{int32},uInt32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,rosetteType,gageOrientation,rosetteMeasTypes,numRosetteMeasTypes,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,nominalGageResistance,poissonRatio,leadWireResistance)
+function DAQmxCreateAIRosetteStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,rosetteType::int32,gageOrientation::float64,rosetteMeasTypes::Ptr{int32},numRosetteMeasTypes::uInt32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64)
+    ccall((:DAQmxCreateAIRosetteStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,Ptr{int32},uInt32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,rosetteType,gageOrientation,rosetteMeasTypes,numRosetteMeasTypes,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,nominalGageResistance,poissonRatio,leadWireResistance)
 end
 
-function DAQmxCreateAIForceBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
+function DAQmxCreateAIForceBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIForceBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
+function DAQmxCreateAIForceBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIForceBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
+function DAQmxCreateAIForceBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIPressureBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPressureBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
+function DAQmxCreateAIPressureBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPressureBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIPressureBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPressureBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
+function DAQmxCreateAIPressureBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPressureBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIPressureBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPressureBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
+function DAQmxCreateAIPressureBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPressureBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAITorqueBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAITorqueBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
+function DAQmxCreateAITorqueBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAITorqueBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAITorqueBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAITorqueBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
+function DAQmxCreateAITorqueBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAITorqueBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAITorqueBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAITorqueBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
+function DAQmxCreateAITorqueBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAITorqueBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,customScaleName)
+function DAQmxCreateAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,customScaleName)
 end
 
-function DAQmxCreateAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,useExcitForScaling::bool32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,int32,float64,bool32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,useExcitForScaling,customScaleName)
+function DAQmxCreateAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,useExcitForScaling::bool32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,int32,float64,bool32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,useExcitForScaling,customScaleName)
 end
 
-function DAQmxCreateAITempBuiltInSensorChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32)
-    ccall((:DAQmxCreateAITempBuiltInSensorChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
+function DAQmxCreateAITempBuiltInSensorChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32)
+    ccall((:DAQmxCreateAITempBuiltInSensorChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
 end
 
-function DAQmxCreateAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIVelocityIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVelocityIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIVelocityIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVelocityIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,units::int32,micSensitivity::float64,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,float64,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,micSensitivity,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,units::int32,micSensitivity::float64,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,float64,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,micSensitivity,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateAIPosEddyCurrProxProbeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPosEddyCurrProxProbeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,customScaleName)
+function DAQmxCreateAIPosEddyCurrProxProbeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPosEddyCurrProxProbeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,customScaleName)
 end
 
-function DAQmxCreateAIDeviceTempChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32)
-    ccall((:DAQmxCreateAIDeviceTempChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
+function DAQmxCreateAIDeviceTempChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32)
+    ccall((:DAQmxCreateAIDeviceTempChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
 end
 
-function DAQmxCreateTEDSAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
+function DAQmxCreateTEDSAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateTEDSAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
+function DAQmxCreateTEDSAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,cjcSource,cjcVal,cjcChannel)
+function DAQmxCreateTEDSAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,cjcSource,cjcVal,cjcChannel)
 end
 
-function DAQmxCreateTEDSAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
-    ccall((:DAQmxCreateTEDSAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
+function DAQmxCreateTEDSAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
+    ccall((:DAQmxCreateTEDSAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
 end
 
-function DAQmxCreateTEDSAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
-    ccall((:DAQmxCreateTEDSAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
+function DAQmxCreateTEDSAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
+    ccall((:DAQmxCreateTEDSAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
 end
 
-function DAQmxCreateTEDSAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,r1::float64)
-    ccall((:DAQmxCreateTEDSAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,r1)
+function DAQmxCreateTEDSAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,r1::float64)
+    ccall((:DAQmxCreateTEDSAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,r1)
 end
 
-function DAQmxCreateTEDSAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,initialBridgeVoltage::float64,leadWireResistance::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,initialBridgeVoltage,leadWireResistance,customScaleName)
+function DAQmxCreateTEDSAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,initialBridgeVoltage::float64,leadWireResistance::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,initialBridgeVoltage,leadWireResistance,customScaleName)
 end
 
-function DAQmxCreateTEDSAIForceBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIForceBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIForceBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIForceBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIPressureBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIPressureBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIPressureBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIPressureBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAITorqueBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAITorqueBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAITorqueBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAITorqueBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,units::int32,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,units::int32,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateTEDSAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateTEDSAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateTEDSAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateAOVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAOVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAOVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAOVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAOCurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAOCurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAOCurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAOCurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAOFuncGenChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},_type::int32,freq::float64,amplitude::float64,offset::float64)
-    ccall((:DAQmxCreateAOFuncGenChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,_type,freq,amplitude,offset)
+function DAQmxCreateAOFuncGenChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},_type::int32,freq::float64,amplitude::float64,offset::float64)
+    ccall((:DAQmxCreateAOFuncGenChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,_type,freq,amplitude,offset)
 end
 
-function DAQmxCreateDIChan(taskHandle::TaskHandle,lines::Ptr{Uint8},nameToAssignToLines::Ptr{Uint8},lineGrouping::int32)
-    ccall((:DAQmxCreateDIChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
+function DAQmxCreateDIChan(taskHandle::TaskHandle,lines::Ptr{UInt8},nameToAssignToLines::Ptr{UInt8},lineGrouping::int32)
+    ccall((:DAQmxCreateDIChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
 end
 
-function DAQmxCreateDOChan(taskHandle::TaskHandle,lines::Ptr{Uint8},nameToAssignToLines::Ptr{Uint8},lineGrouping::int32)
-    ccall((:DAQmxCreateDOChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
+function DAQmxCreateDOChan(taskHandle::TaskHandle,lines::Ptr{UInt8},nameToAssignToLines::Ptr{UInt8},lineGrouping::int32)
+    ccall((:DAQmxCreateDOChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
 end
 
-function DAQmxCreateCIFreqChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIFreqChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
+function DAQmxCreateCIFreqChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIFreqChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
 end
 
-function DAQmxCreateCIPeriodChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
+function DAQmxCreateCIPeriodChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
 end
 
-function DAQmxCreateCICountEdgesChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},edge::int32,initialCount::uInt32,countDirection::int32)
-    ccall((:DAQmxCreateCICountEdgesChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,uInt32,int32),taskHandle,counter,nameToAssignToChannel,edge,initialCount,countDirection)
+function DAQmxCreateCICountEdgesChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},edge::int32,initialCount::uInt32,countDirection::int32)
+    ccall((:DAQmxCreateCICountEdgesChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,uInt32,int32),taskHandle,counter,nameToAssignToChannel,edge,initialCount,countDirection)
 end
 
-function DAQmxCreateCIPulseWidthChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,startingEdge::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIPulseWidthChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,startingEdge,customScaleName)
+function DAQmxCreateCIPulseWidthChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,startingEdge::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIPulseWidthChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,startingEdge,customScaleName)
 end
 
-function DAQmxCreateCISemiPeriodChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCISemiPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
+function DAQmxCreateCISemiPeriodChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCISemiPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateCITwoEdgeSepChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,firstEdge::int32,secondEdge::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCITwoEdgeSepChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,firstEdge,secondEdge,customScaleName)
+function DAQmxCreateCITwoEdgeSepChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,firstEdge::int32,secondEdge::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCITwoEdgeSepChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,firstEdge,secondEdge,customScaleName)
 end
 
-function DAQmxCreateCIPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32)
-    ccall((:DAQmxCreateCIPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
+function DAQmxCreateCIPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32)
+    ccall((:DAQmxCreateCIPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
 end
 
-function DAQmxCreateCIPulseChanTime(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32)
-    ccall((:DAQmxCreateCIPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
+function DAQmxCreateCIPulseChanTime(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32)
+    ccall((:DAQmxCreateCIPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
 end
 
-function DAQmxCreateCIPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},sourceTerminal::Ptr{Uint8},minVal::float64,maxVal::float64)
-    ccall((:DAQmxCreateCIPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},float64,float64),taskHandle,counter,nameToAssignToChannel,sourceTerminal,minVal,maxVal)
+function DAQmxCreateCIPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},sourceTerminal::Ptr{UInt8},minVal::float64,maxVal::float64)
+    ccall((:DAQmxCreateCIPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},float64,float64),taskHandle,counter,nameToAssignToChannel,sourceTerminal,minVal,maxVal)
 end
 
-function DAQmxCreateCILinEncoderChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,distPerPulse::float64,initialPos::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCILinEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,bool32,float64,int32,int32,float64,float64,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,distPerPulse,initialPos,customScaleName)
+function DAQmxCreateCILinEncoderChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,distPerPulse::float64,initialPos::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCILinEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,bool32,float64,int32,int32,float64,float64,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,distPerPulse,initialPos,customScaleName)
 end
 
-function DAQmxCreateCIAngEncoderChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,pulsesPerRev::uInt32,initialAngle::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIAngEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,bool32,float64,int32,int32,uInt32,float64,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,pulsesPerRev,initialAngle,customScaleName)
+function DAQmxCreateCIAngEncoderChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,pulsesPerRev::uInt32,initialAngle::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIAngEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,bool32,float64,int32,int32,uInt32,float64,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,pulsesPerRev,initialAngle,customScaleName)
 end
 
-function DAQmxCreateCIGPSTimestampChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32,syncMethod::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIGPSTimestampChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,units,syncMethod,customScaleName)
+function DAQmxCreateCIGPSTimestampChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32,syncMethod::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIGPSTimestampChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,units,syncMethod,customScaleName)
 end
 
-function DAQmxCreateCOPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32,idleState::int32,initialDelay::float64,freq::float64,dutyCycle::float64)
-    ccall((:DAQmxCreateCOPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,freq,dutyCycle)
+function DAQmxCreateCOPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32,idleState::int32,initialDelay::float64,freq::float64,dutyCycle::float64)
+    ccall((:DAQmxCreateCOPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,freq,dutyCycle)
 end
 
-function DAQmxCreateCOPulseChanTime(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32,idleState::int32,initialDelay::float64,lowTime::float64,highTime::float64)
-    ccall((:DAQmxCreateCOPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,lowTime,highTime)
+function DAQmxCreateCOPulseChanTime(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32,idleState::int32,initialDelay::float64,lowTime::float64,highTime::float64)
+    ccall((:DAQmxCreateCOPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,lowTime,highTime)
 end
 
-function DAQmxCreateCOPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},sourceTerminal::Ptr{Uint8},idleState::int32,initialDelay::int32,lowTicks::int32,highTicks::int32)
-    ccall((:DAQmxCreateCOPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},int32,int32,int32,int32),taskHandle,counter,nameToAssignToChannel,sourceTerminal,idleState,initialDelay,lowTicks,highTicks)
+function DAQmxCreateCOPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},sourceTerminal::Ptr{UInt8},idleState::int32,initialDelay::int32,lowTicks::int32,highTicks::int32)
+    ccall((:DAQmxCreateCOPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},int32,int32,int32,int32),taskHandle,counter,nameToAssignToChannel,sourceTerminal,idleState,initialDelay,lowTicks,highTicks)
 end
 
-function DAQmxGetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxGetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxSetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
-    ccall((:DAQmxSetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxSetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
+    ccall((:DAQmxSetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxGetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxGetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxSetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
-    ccall((:DAQmxSetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxSetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
+    ccall((:DAQmxSetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxResetChanAttribute(taskHandle::TaskHandle,channel::Ptr{Uint8},attribute::int32)
-    ccall((:DAQmxResetChanAttribute,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,attribute)
+function DAQmxResetChanAttribute(taskHandle::TaskHandle,channel::Ptr{UInt8},attribute::int32)
+    ccall((:DAQmxResetChanAttribute,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,attribute)
 end
 
-function DAQmxCfgSampClkTiming(taskHandle::TaskHandle,source::Ptr{Uint8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
-    ccall((:DAQmxCfgSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
+function DAQmxCfgSampClkTiming(taskHandle::TaskHandle,source::Ptr{UInt8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
+    ccall((:DAQmxCfgSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
 end
 
 function DAQmxCfgHandshakingTiming(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64)
     ccall((:DAQmxCfgHandshakingTiming,NIDAQmx),int32,(TaskHandle,int32,uInt64),taskHandle,sampleMode,sampsPerChan)
 end
 
-function DAQmxCfgBurstHandshakingTimingImportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkSrc::Ptr{Uint8},sampleClkActiveEdge::int32,pauseWhen::int32,readyEventActiveLevel::int32)
-    ccall((:DAQmxCfgBurstHandshakingTimingImportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{Uint8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkSrc,sampleClkActiveEdge,pauseWhen,readyEventActiveLevel)
+function DAQmxCfgBurstHandshakingTimingImportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkSrc::Ptr{UInt8},sampleClkActiveEdge::int32,pauseWhen::int32,readyEventActiveLevel::int32)
+    ccall((:DAQmxCfgBurstHandshakingTimingImportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{UInt8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkSrc,sampleClkActiveEdge,pauseWhen,readyEventActiveLevel)
 end
 
-function DAQmxCfgBurstHandshakingTimingExportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkOutpTerm::Ptr{Uint8},sampleClkPulsePolarity::int32,pauseWhen::int32,readyEventActiveLevel::int32)
-    ccall((:DAQmxCfgBurstHandshakingTimingExportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{Uint8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkOutpTerm,sampleClkPulsePolarity,pauseWhen,readyEventActiveLevel)
+function DAQmxCfgBurstHandshakingTimingExportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkOutpTerm::Ptr{UInt8},sampleClkPulsePolarity::int32,pauseWhen::int32,readyEventActiveLevel::int32)
+    ccall((:DAQmxCfgBurstHandshakingTimingExportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{UInt8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkOutpTerm,sampleClkPulsePolarity,pauseWhen,readyEventActiveLevel)
 end
 
-function DAQmxCfgChangeDetectionTiming(taskHandle::TaskHandle,risingEdgeChan::Ptr{Uint8},fallingEdgeChan::Ptr{Uint8},sampleMode::int32,sampsPerChan::uInt64)
-    ccall((:DAQmxCfgChangeDetectionTiming,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,uInt64),taskHandle,risingEdgeChan,fallingEdgeChan,sampleMode,sampsPerChan)
+function DAQmxCfgChangeDetectionTiming(taskHandle::TaskHandle,risingEdgeChan::Ptr{UInt8},fallingEdgeChan::Ptr{UInt8},sampleMode::int32,sampsPerChan::uInt64)
+    ccall((:DAQmxCfgChangeDetectionTiming,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,uInt64),taskHandle,risingEdgeChan,fallingEdgeChan,sampleMode,sampsPerChan)
 end
 
 function DAQmxCfgImplicitTiming(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64)
     ccall((:DAQmxCfgImplicitTiming,NIDAQmx),int32,(TaskHandle,int32,uInt64),taskHandle,sampleMode,sampsPerChan)
 end
 
-function DAQmxCfgPipelinedSampClkTiming(taskHandle::TaskHandle,source::Ptr{Uint8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
-    ccall((:DAQmxCfgPipelinedSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
+function DAQmxCfgPipelinedSampClkTiming(taskHandle::TaskHandle,source::Ptr{UInt8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
+    ccall((:DAQmxCfgPipelinedSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
 end
 
 function DAQmxResetTimingAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetTimingAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxResetTimingAttributeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},attribute::int32)
-    ccall((:DAQmxResetTimingAttributeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,attribute)
+function DAQmxResetTimingAttributeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},attribute::int32)
+    ccall((:DAQmxResetTimingAttributeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,attribute)
 end
 
 function DAQmxDisableStartTrig(taskHandle::TaskHandle)
     ccall((:DAQmxDisableStartTrig,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxCfgDigEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerEdge::int32)
-    ccall((:DAQmxCfgDigEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,triggerSource,triggerEdge)
+function DAQmxCfgDigEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerEdge::int32)
+    ccall((:DAQmxCfgDigEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,triggerSource,triggerEdge)
 end
 
-function DAQmxCfgAnlgEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerSlope::int32,triggerLevel::float64)
-    ccall((:DAQmxCfgAnlgEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64),taskHandle,triggerSource,triggerSlope,triggerLevel)
+function DAQmxCfgAnlgEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerSlope::int32,triggerLevel::float64)
+    ccall((:DAQmxCfgAnlgEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64),taskHandle,triggerSource,triggerSlope,triggerLevel)
 end
 
-function DAQmxCfgAnlgWindowStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerWhen::int32,windowTop::float64,windowBottom::float64)
-    ccall((:DAQmxCfgAnlgWindowStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64,float64),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom)
+function DAQmxCfgAnlgWindowStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerWhen::int32,windowTop::float64,windowBottom::float64)
+    ccall((:DAQmxCfgAnlgWindowStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64,float64),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom)
 end
 
-function DAQmxCfgDigPatternStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerPattern::Ptr{Uint8},triggerWhen::int32)
-    ccall((:DAQmxCfgDigPatternStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,triggerSource,triggerPattern,triggerWhen)
+function DAQmxCfgDigPatternStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerPattern::Ptr{UInt8},triggerWhen::int32)
+    ccall((:DAQmxCfgDigPatternStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,triggerSource,triggerPattern,triggerWhen)
 end
 
 function DAQmxDisableRefTrig(taskHandle::TaskHandle)
     ccall((:DAQmxDisableRefTrig,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxCfgDigEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerEdge::int32,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgDigEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,uInt32),taskHandle,triggerSource,triggerEdge,pretriggerSamples)
+function DAQmxCfgDigEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerEdge::int32,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgDigEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,uInt32),taskHandle,triggerSource,triggerEdge,pretriggerSamples)
 end
 
-function DAQmxCfgAnlgEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerSlope::int32,triggerLevel::float64,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgAnlgEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64,uInt32),taskHandle,triggerSource,triggerSlope,triggerLevel,pretriggerSamples)
+function DAQmxCfgAnlgEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerSlope::int32,triggerLevel::float64,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgAnlgEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64,uInt32),taskHandle,triggerSource,triggerSlope,triggerLevel,pretriggerSamples)
 end
 
-function DAQmxCfgAnlgWindowRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerWhen::int32,windowTop::float64,windowBottom::float64,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgAnlgWindowRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64,float64,uInt32),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom,pretriggerSamples)
+function DAQmxCfgAnlgWindowRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerWhen::int32,windowTop::float64,windowBottom::float64,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgAnlgWindowRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64,float64,uInt32),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom,pretriggerSamples)
 end
 
-function DAQmxCfgDigPatternRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerPattern::Ptr{Uint8},triggerWhen::int32,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgDigPatternRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,uInt32),taskHandle,triggerSource,triggerPattern,triggerWhen,pretriggerSamples)
+function DAQmxCfgDigPatternRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerPattern::Ptr{UInt8},triggerWhen::int32,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgDigPatternRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,uInt32),taskHandle,triggerSource,triggerPattern,triggerWhen,pretriggerSamples)
 end
 
 function DAQmxDisableAdvTrig(taskHandle::TaskHandle)
     ccall((:DAQmxDisableAdvTrig,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxCfgDigEdgeAdvTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerEdge::int32)
-    ccall((:DAQmxCfgDigEdgeAdvTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,triggerSource,triggerEdge)
+function DAQmxCfgDigEdgeAdvTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerEdge::int32)
+    ccall((:DAQmxCfgDigEdgeAdvTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,triggerSource,triggerEdge)
 end
 
 function DAQmxResetTrigAttribute(taskHandle::TaskHandle,attribute::int32)
@@ -538,20 +538,20 @@ function DAQmxReadRaw(taskHandle::TaskHandle,numSampsPerChan::int32,timeout::flo
     ccall((:DAQmxReadRaw,NIDAQmx),int32,(TaskHandle,int32,float64,Ptr{Void},uInt32,Ptr{int32},Ptr{int32},Ptr{bool32}),taskHandle,numSampsPerChan,timeout,readArray,arraySizeInBytes,sampsRead,numBytesPerSamp,reserved)
 end
 
-function DAQmxGetNthTaskReadChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{Uint8},bufferSize::int32)
-    ccall((:DAQmxGetNthTaskReadChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{Uint8},int32),taskHandle,index,buffer,bufferSize)
+function DAQmxGetNthTaskReadChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{UInt8},bufferSize::int32)
+    ccall((:DAQmxGetNthTaskReadChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{UInt8},int32),taskHandle,index,buffer,bufferSize)
 end
 
 function DAQmxResetReadAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetReadAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxConfigureLogging(taskHandle::TaskHandle,filePath::Ptr{Uint8},loggingMode::int32,groupName::Ptr{Uint8},operation::int32)
-    ccall((:DAQmxConfigureLogging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,Ptr{Uint8},int32),taskHandle,filePath,loggingMode,groupName,operation)
+function DAQmxConfigureLogging(taskHandle::TaskHandle,filePath::Ptr{UInt8},loggingMode::int32,groupName::Ptr{UInt8},operation::int32)
+    ccall((:DAQmxConfigureLogging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,Ptr{UInt8},int32),taskHandle,filePath,loggingMode,groupName,operation)
 end
 
-function DAQmxStartNewFile(taskHandle::TaskHandle,filePath::Ptr{Uint8})
-    ccall((:DAQmxStartNewFile,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,filePath)
+function DAQmxStartNewFile(taskHandle::TaskHandle,filePath::Ptr{UInt8})
+    ccall((:DAQmxStartNewFile,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,filePath)
 end
 
 function DAQmxWriteAnalogF64(taskHandle::TaskHandle,numSampsPerChan::int32,autoStart::bool32,timeout::float64,dataLayout::bool32,writeArray::Ptr{float64},sampsPerChanWritten::Ptr{int32},reserved::Ptr{bool32})
@@ -630,28 +630,28 @@ function DAQmxResetWriteAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetWriteAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxExportSignal(taskHandle::TaskHandle,signalID::int32,outputTerminal::Ptr{Uint8})
-    ccall((:DAQmxExportSignal,NIDAQmx),int32,(TaskHandle,int32,Ptr{Uint8}),taskHandle,signalID,outputTerminal)
+function DAQmxExportSignal(taskHandle::TaskHandle,signalID::int32,outputTerminal::Ptr{UInt8})
+    ccall((:DAQmxExportSignal,NIDAQmx),int32,(TaskHandle,int32,Ptr{UInt8}),taskHandle,signalID,outputTerminal)
 end
 
 function DAQmxResetExportedSignalAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetExportedSignalAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxCreateLinScale(name::Ptr{Uint8},slope::float64,yIntercept::float64,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreateLinScale,NIDAQmx),int32,(Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),name,slope,yIntercept,preScaledUnits,scaledUnits)
+function DAQmxCreateLinScale(name::Ptr{UInt8},slope::float64,yIntercept::float64,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreateLinScale,NIDAQmx),int32,(Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),name,slope,yIntercept,preScaledUnits,scaledUnits)
 end
 
-function DAQmxCreateMapScale(name::Ptr{Uint8},prescaledMin::float64,prescaledMax::float64,scaledMin::float64,scaledMax::float64,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreateMapScale,NIDAQmx),int32,(Ptr{Uint8},float64,float64,float64,float64,int32,Ptr{Uint8}),name,prescaledMin,prescaledMax,scaledMin,scaledMax,preScaledUnits,scaledUnits)
+function DAQmxCreateMapScale(name::Ptr{UInt8},prescaledMin::float64,prescaledMax::float64,scaledMin::float64,scaledMax::float64,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreateMapScale,NIDAQmx),int32,(Ptr{UInt8},float64,float64,float64,float64,int32,Ptr{UInt8}),name,prescaledMin,prescaledMax,scaledMin,scaledMax,preScaledUnits,scaledUnits)
 end
 
-function DAQmxCreatePolynomialScale(name::Ptr{Uint8},forwardCoeffs::Ptr{float64},numForwardCoeffsIn::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreatePolynomialScale,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{Uint8}),name,forwardCoeffs,numForwardCoeffsIn,reverseCoeffs,numReverseCoeffsIn,preScaledUnits,scaledUnits)
+function DAQmxCreatePolynomialScale(name::Ptr{UInt8},forwardCoeffs::Ptr{float64},numForwardCoeffsIn::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreatePolynomialScale,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{UInt8}),name,forwardCoeffs,numForwardCoeffsIn,reverseCoeffs,numReverseCoeffsIn,preScaledUnits,scaledUnits)
 end
 
-function DAQmxCreateTableScale(name::Ptr{Uint8},prescaledVals::Ptr{float64},numPrescaledValsIn::uInt32,scaledVals::Ptr{float64},numScaledValsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreateTableScale,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{Uint8}),name,prescaledVals,numPrescaledValsIn,scaledVals,numScaledValsIn,preScaledUnits,scaledUnits)
+function DAQmxCreateTableScale(name::Ptr{UInt8},prescaledVals::Ptr{float64},numPrescaledValsIn::uInt32,scaledVals::Ptr{float64},numScaledValsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreateTableScale,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{UInt8}),name,prescaledVals,numPrescaledValsIn,scaledVals,numScaledValsIn,preScaledUnits,scaledUnits)
 end
 
 function DAQmxCalculateReversePolyCoeff(forwardCoeffs::Ptr{float64},numForwardCoeffsIn::uInt32,minValX::float64,maxValX::float64,numPointsToCompute::int32,reversePolyOrder::int32,reverseCoeffs::Ptr{float64})
@@ -674,68 +674,68 @@ function DAQmxResetBufferAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetBufferAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxSwitchCreateScanList(scanList::Ptr{Uint8},taskHandle::Ptr{TaskHandle})
-    ccall((:DAQmxSwitchCreateScanList,NIDAQmx),int32,(Ptr{Uint8},Ptr{TaskHandle}),scanList,taskHandle)
+function DAQmxSwitchCreateScanList(scanList::Ptr{UInt8},taskHandle::Ptr{TaskHandle})
+    ccall((:DAQmxSwitchCreateScanList,NIDAQmx),int32,(Ptr{UInt8},Ptr{TaskHandle}),scanList,taskHandle)
 end
 
-function DAQmxSwitchConnect(switchChannel1::Ptr{Uint8},switchChannel2::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchConnect,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},bool32),switchChannel1,switchChannel2,waitForSettling)
+function DAQmxSwitchConnect(switchChannel1::Ptr{UInt8},switchChannel2::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchConnect,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},bool32),switchChannel1,switchChannel2,waitForSettling)
 end
 
-function DAQmxSwitchConnectMulti(connectionList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchConnectMulti,NIDAQmx),int32,(Ptr{Uint8},bool32),connectionList,waitForSettling)
+function DAQmxSwitchConnectMulti(connectionList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchConnectMulti,NIDAQmx),int32,(Ptr{UInt8},bool32),connectionList,waitForSettling)
 end
 
-function DAQmxSwitchDisconnect(switchChannel1::Ptr{Uint8},switchChannel2::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchDisconnect,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},bool32),switchChannel1,switchChannel2,waitForSettling)
+function DAQmxSwitchDisconnect(switchChannel1::Ptr{UInt8},switchChannel2::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchDisconnect,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},bool32),switchChannel1,switchChannel2,waitForSettling)
 end
 
-function DAQmxSwitchDisconnectMulti(connectionList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchDisconnectMulti,NIDAQmx),int32,(Ptr{Uint8},bool32),connectionList,waitForSettling)
+function DAQmxSwitchDisconnectMulti(connectionList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchDisconnectMulti,NIDAQmx),int32,(Ptr{UInt8},bool32),connectionList,waitForSettling)
 end
 
-function DAQmxSwitchDisconnectAll(deviceName::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchDisconnectAll,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,waitForSettling)
+function DAQmxSwitchDisconnectAll(deviceName::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchDisconnectAll,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,waitForSettling)
 end
 
-function DAQmxSwitchSetTopologyAndReset(deviceName::Ptr{Uint8},newTopology::Ptr{Uint8})
-    ccall((:DAQmxSwitchSetTopologyAndReset,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),deviceName,newTopology)
+function DAQmxSwitchSetTopologyAndReset(deviceName::Ptr{UInt8},newTopology::Ptr{UInt8})
+    ccall((:DAQmxSwitchSetTopologyAndReset,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),deviceName,newTopology)
 end
 
-function DAQmxSwitchFindPath(switchChannel1::Ptr{Uint8},switchChannel2::Ptr{Uint8},path::Ptr{Uint8},pathBufferSize::uInt32,pathStatus::Ptr{int32})
-    ccall((:DAQmxSwitchFindPath,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32,Ptr{int32}),switchChannel1,switchChannel2,path,pathBufferSize,pathStatus)
+function DAQmxSwitchFindPath(switchChannel1::Ptr{UInt8},switchChannel2::Ptr{UInt8},path::Ptr{UInt8},pathBufferSize::uInt32,pathStatus::Ptr{int32})
+    ccall((:DAQmxSwitchFindPath,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32,Ptr{int32}),switchChannel1,switchChannel2,path,pathBufferSize,pathStatus)
 end
 
-function DAQmxSwitchOpenRelays(relayList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchOpenRelays,NIDAQmx),int32,(Ptr{Uint8},bool32),relayList,waitForSettling)
+function DAQmxSwitchOpenRelays(relayList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchOpenRelays,NIDAQmx),int32,(Ptr{UInt8},bool32),relayList,waitForSettling)
 end
 
-function DAQmxSwitchCloseRelays(relayList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchCloseRelays,NIDAQmx),int32,(Ptr{Uint8},bool32),relayList,waitForSettling)
+function DAQmxSwitchCloseRelays(relayList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchCloseRelays,NIDAQmx),int32,(Ptr{UInt8},bool32),relayList,waitForSettling)
 end
 
-function DAQmxSwitchGetSingleRelayCount(relayName::Ptr{Uint8},count::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetSingleRelayCount,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),relayName,count)
+function DAQmxSwitchGetSingleRelayCount(relayName::Ptr{UInt8},count::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetSingleRelayCount,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),relayName,count)
 end
 
-function DAQmxSwitchGetMultiRelayCount(relayList::Ptr{Uint8},count::Ptr{uInt32},countArraySize::uInt32,numRelayCountsRead::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetMultiRelayCount,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,count,countArraySize,numRelayCountsRead)
+function DAQmxSwitchGetMultiRelayCount(relayList::Ptr{UInt8},count::Ptr{uInt32},countArraySize::uInt32,numRelayCountsRead::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetMultiRelayCount,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,count,countArraySize,numRelayCountsRead)
 end
 
-function DAQmxSwitchGetSingleRelayPos(relayName::Ptr{Uint8},relayPos::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetSingleRelayPos,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),relayName,relayPos)
+function DAQmxSwitchGetSingleRelayPos(relayName::Ptr{UInt8},relayPos::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetSingleRelayPos,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),relayName,relayPos)
 end
 
-function DAQmxSwitchGetMultiRelayPos(relayList::Ptr{Uint8},relayPos::Ptr{uInt32},relayPosArraySize::uInt32,numRelayPossRead::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetMultiRelayPos,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,relayPos,relayPosArraySize,numRelayPossRead)
+function DAQmxSwitchGetMultiRelayPos(relayList::Ptr{UInt8},relayPos::Ptr{uInt32},relayPosArraySize::uInt32,numRelayPossRead::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetMultiRelayPos,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,relayPos,relayPosArraySize,numRelayPossRead)
 end
 
-function DAQmxSwitchWaitForSettling(deviceName::Ptr{Uint8})
-    ccall((:DAQmxSwitchWaitForSettling,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxSwitchWaitForSettling(deviceName::Ptr{UInt8})
+    ccall((:DAQmxSwitchWaitForSettling,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxGetSwitchChanAttribute(switchChannelName::Ptr{Uint8},attribute::int32,value::Ptr{Void})
-    ccall((:DAQmxGetSwitchChanAttribute,NIDAQmx),int32,(Ptr{Uint8},int32,Ptr{Void}),switchChannelName,attribute,value)
+function DAQmxGetSwitchChanAttribute(switchChannelName::Ptr{UInt8},attribute::int32,value::Ptr{Void})
+    ccall((:DAQmxGetSwitchChanAttribute,NIDAQmx),int32,(Ptr{UInt8},int32,Ptr{Void}),switchChannelName,attribute,value)
 end
 
 function DAQmxGetSwitchScanAttribute(taskHandle::TaskHandle,attribute::int32,value::Ptr{Void})
@@ -746,84 +746,84 @@ function DAQmxResetSwitchScanAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetSwitchScanAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxConnectTerms(sourceTerminal::Ptr{Uint8},destinationTerminal::Ptr{Uint8},signalModifiers::int32)
-    ccall((:DAQmxConnectTerms,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},int32),sourceTerminal,destinationTerminal,signalModifiers)
+function DAQmxConnectTerms(sourceTerminal::Ptr{UInt8},destinationTerminal::Ptr{UInt8},signalModifiers::int32)
+    ccall((:DAQmxConnectTerms,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},int32),sourceTerminal,destinationTerminal,signalModifiers)
 end
 
-function DAQmxDisconnectTerms(sourceTerminal::Ptr{Uint8},destinationTerminal::Ptr{Uint8})
-    ccall((:DAQmxDisconnectTerms,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),sourceTerminal,destinationTerminal)
+function DAQmxDisconnectTerms(sourceTerminal::Ptr{UInt8},destinationTerminal::Ptr{UInt8})
+    ccall((:DAQmxDisconnectTerms,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),sourceTerminal,destinationTerminal)
 end
 
-function DAQmxTristateOutputTerm(outputTerminal::Ptr{Uint8})
-    ccall((:DAQmxTristateOutputTerm,NIDAQmx),int32,(Ptr{Uint8},),outputTerminal)
+function DAQmxTristateOutputTerm(outputTerminal::Ptr{UInt8})
+    ccall((:DAQmxTristateOutputTerm,NIDAQmx),int32,(Ptr{UInt8},),outputTerminal)
 end
 
-function DAQmxResetDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxResetDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxResetDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxResetDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxSelfTestDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxSelfTestDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxSelfTestDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxSelfTestDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxCreateWatchdogTimerTaskEx(deviceName::Ptr{Uint8},taskName::Ptr{Uint8},taskHandle::Ptr{TaskHandle},timeout::float64)
-    ccall((:DAQmxCreateWatchdogTimerTaskEx,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{TaskHandle},float64),deviceName,taskName,taskHandle,timeout)
+function DAQmxCreateWatchdogTimerTaskEx(deviceName::Ptr{UInt8},taskName::Ptr{UInt8},taskHandle::Ptr{TaskHandle},timeout::float64)
+    ccall((:DAQmxCreateWatchdogTimerTaskEx,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{TaskHandle},float64),deviceName,taskName,taskHandle,timeout)
 end
 
 function DAQmxControlWatchdogTask(taskHandle::TaskHandle,action::int32)
     ccall((:DAQmxControlWatchdogTask,NIDAQmx),int32,(TaskHandle,int32),taskHandle,action)
 end
 
-function DAQmxCfgWatchdogAOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{Uint8},expirStateArray::Ptr{float64},outputTypeArray::Ptr{int32},arraySize::uInt32)
-    ccall((:DAQmxCfgWatchdogAOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,outputTypeArray,arraySize)
+function DAQmxCfgWatchdogAOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{UInt8},expirStateArray::Ptr{float64},outputTypeArray::Ptr{int32},arraySize::uInt32)
+    ccall((:DAQmxCfgWatchdogAOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,outputTypeArray,arraySize)
 end
 
-function DAQmxCfgWatchdogCOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{Uint8},expirStateArray::Ptr{int32},arraySize::uInt32)
-    ccall((:DAQmxCfgWatchdogCOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,arraySize)
+function DAQmxCfgWatchdogCOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{UInt8},expirStateArray::Ptr{int32},arraySize::uInt32)
+    ccall((:DAQmxCfgWatchdogCOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,arraySize)
 end
 
-function DAQmxCfgWatchdogDOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{Uint8},expirStateArray::Ptr{int32},arraySize::uInt32)
-    ccall((:DAQmxCfgWatchdogDOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,arraySize)
+function DAQmxCfgWatchdogDOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{UInt8},expirStateArray::Ptr{int32},arraySize::uInt32)
+    ccall((:DAQmxCfgWatchdogDOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,arraySize)
 end
 
-function DAQmxResetWatchdogAttribute(taskHandle::TaskHandle,lines::Ptr{Uint8},attribute::int32)
-    ccall((:DAQmxResetWatchdogAttribute,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,attribute)
+function DAQmxResetWatchdogAttribute(taskHandle::TaskHandle,lines::Ptr{UInt8},attribute::int32)
+    ccall((:DAQmxResetWatchdogAttribute,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,attribute)
 end
 
-function DAQmxSelfCal(deviceName::Ptr{Uint8})
-    ccall((:DAQmxSelfCal,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxSelfCal(deviceName::Ptr{UInt8})
+    ccall((:DAQmxSelfCal,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxPerformBridgeOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxPerformBridgeOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxPerformBridgeOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxPerformBridgeOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxPerformBridgeOffsetNullingCalEx(taskHandle::TaskHandle,channel::Ptr{Uint8},skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformBridgeOffsetNullingCalEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,skipUnsupportedChannels)
+function DAQmxPerformBridgeOffsetNullingCalEx(taskHandle::TaskHandle,channel::Ptr{UInt8},skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformBridgeOffsetNullingCalEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,skipUnsupportedChannels)
 end
 
-function DAQmxPerformThrmcplLeadOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{Uint8},skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformThrmcplLeadOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,skipUnsupportedChannels)
+function DAQmxPerformThrmcplLeadOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{UInt8},skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformThrmcplLeadOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,skipUnsupportedChannels)
 end
 
-function DAQmxPerformStrainShuntCal(taskHandle::TaskHandle,channel::Ptr{Uint8},shuntResistorValue::float64,shuntResistorLocation::int32,skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformStrainShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,skipUnsupportedChannels)
+function DAQmxPerformStrainShuntCal(taskHandle::TaskHandle,channel::Ptr{UInt8},shuntResistorValue::float64,shuntResistorLocation::int32,skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformStrainShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,skipUnsupportedChannels)
 end
 
-function DAQmxPerformBridgeShuntCal(taskHandle::TaskHandle,channel::Ptr{Uint8},shuntResistorValue::float64,shuntResistorLocation::int32,bridgeResistance::float64,skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformBridgeShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,float64,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,bridgeResistance,skipUnsupportedChannels)
+function DAQmxPerformBridgeShuntCal(taskHandle::TaskHandle,channel::Ptr{UInt8},shuntResistorValue::float64,shuntResistorLocation::int32,bridgeResistance::float64,skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformBridgeShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,float64,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,bridgeResistance,skipUnsupportedChannels)
 end
 
-function DAQmxGetSelfCalLastDateAndTime(deviceName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetSelfCalLastDateAndTime,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
+function DAQmxGetSelfCalLastDateAndTime(deviceName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetSelfCalLastDateAndTime,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
 end
 
-function DAQmxGetExtCalLastDateAndTime(deviceName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetExtCalLastDateAndTime,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
+function DAQmxGetExtCalLastDateAndTime(deviceName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetExtCalLastDateAndTime,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
 end
 
-function DAQmxRestoreLastExtCalConst(deviceName::Ptr{Uint8})
-    ccall((:DAQmxRestoreLastExtCalConst,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxRestoreLastExtCalConst(deviceName::Ptr{UInt8})
+    ccall((:DAQmxRestoreLastExtCalConst,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
 function DAQmxESeriesCalAdjust(calHandle::CalHandle,referenceVoltage::float64)
@@ -850,20 +850,20 @@ function DAQmxXSeriesCalAdjust(calHandle::CalHandle,referenceVoltage::float64)
     ccall((:DAQmxXSeriesCalAdjust,NIDAQmx),int32,(CalHandle,float64),calHandle,referenceVoltage)
 end
 
-function DAQmxDeviceSupportsCal(deviceName::Ptr{Uint8},calSupported::Ptr{bool32})
-    ccall((:DAQmxDeviceSupportsCal,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,calSupported)
+function DAQmxDeviceSupportsCal(deviceName::Ptr{UInt8},calSupported::Ptr{bool32})
+    ccall((:DAQmxDeviceSupportsCal,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,calSupported)
 end
 
-function DAQmxInitExtCal(deviceName::Ptr{Uint8},password::Ptr{Uint8},calHandle::Ptr{CalHandle})
-    ccall((:DAQmxInitExtCal,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{CalHandle}),deviceName,password,calHandle)
+function DAQmxInitExtCal(deviceName::Ptr{UInt8},password::Ptr{UInt8},calHandle::Ptr{CalHandle})
+    ccall((:DAQmxInitExtCal,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{CalHandle}),deviceName,password,calHandle)
 end
 
 function DAQmxCloseExtCal(calHandle::CalHandle,action::int32)
     ccall((:DAQmxCloseExtCal,NIDAQmx),int32,(CalHandle,int32),calHandle,action)
 end
 
-function DAQmxChangeExtCalPassword(deviceName::Ptr{Uint8},password::Ptr{Uint8},newPassword::Ptr{Uint8})
-    ccall((:DAQmxChangeExtCalPassword,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8}),deviceName,password,newPassword)
+function DAQmxChangeExtCalPassword(deviceName::Ptr{UInt8},password::Ptr{UInt8},newPassword::Ptr{UInt8})
+    ccall((:DAQmxChangeExtCalPassword,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8}),deviceName,password,newPassword)
 end
 
 function DAQmxDSASetCalTemp(calHandle::CalHandle,temperature::float64)
@@ -886,8 +886,8 @@ function DAQmxAdjustDSAAOCal(calHandle::CalHandle,channel::uInt32,requestedLowVo
     ccall((:DAQmxAdjustDSAAOCal,NIDAQmx),int32,(CalHandle,uInt32,float64,float64,float64,float64,float64),calHandle,channel,requestedLowVoltage,actualLowVoltage,requestedHighVoltage,actualHighVoltage,gainSetting)
 end
 
-function DAQmxAdjust4610Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64,offset::float64)
-    ccall((:DAQmxAdjust4610Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelName,gain,offset)
+function DAQmxAdjust4610Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64,offset::float64)
+    ccall((:DAQmxAdjust4610Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelName,gain,offset)
 end
 
 function DAQmxAdjustDSATimebaseCal(calHandle::CalHandle,referenceFrequency::float64)
@@ -906,24 +906,24 @@ function DAQmxAdjustTIOTimebaseCal(calHandle::CalHandle,referenceFrequency::floa
     ccall((:DAQmxAdjustTIOTimebaseCal,NIDAQmx),int32,(CalHandle,float64),calHandle,referenceFrequency)
 end
 
-function DAQmxAdjust4204Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},lowPassFreq::float64,trackHoldEnabled::bool32,inputVal::float64)
-    ccall((:DAQmxAdjust4204Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,bool32,float64),calHandle,channelNames,lowPassFreq,trackHoldEnabled,inputVal)
+function DAQmxAdjust4204Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},lowPassFreq::float64,trackHoldEnabled::bool32,inputVal::float64)
+    ccall((:DAQmxAdjust4204Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,bool32,float64),calHandle,channelNames,lowPassFreq,trackHoldEnabled,inputVal)
 end
 
-function DAQmxAdjust4220Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},gain::float64,inputVal::float64)
-    ccall((:DAQmxAdjust4220Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,gain,inputVal)
+function DAQmxAdjust4220Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},gain::float64,inputVal::float64)
+    ccall((:DAQmxAdjust4220Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,gain,inputVal)
 end
 
-function DAQmxAdjust4224Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},gain::float64,inputVal::float64)
-    ccall((:DAQmxAdjust4224Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,gain,inputVal)
+function DAQmxAdjust4224Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},gain::float64,inputVal::float64)
+    ccall((:DAQmxAdjust4224Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,gain,inputVal)
 end
 
-function DAQmxAdjust4225Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},gain::float64,inputVal::float64)
-    ccall((:DAQmxAdjust4225Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,gain,inputVal)
+function DAQmxAdjust4225Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},gain::float64,inputVal::float64)
+    ccall((:DAQmxAdjust4225Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,gain,inputVal)
 end
 
-function DAQmxSetup433xCal(calHandle::CalHandle,channelNames::Ptr{Uint8},excitationVoltage::float64)
-    ccall((:DAQmxSetup433xCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,excitationVoltage)
+function DAQmxSetup433xCal(calHandle::CalHandle,channelNames::Ptr{UInt8},excitationVoltage::float64)
+    ccall((:DAQmxSetup433xCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,excitationVoltage)
 end
 
 function DAQmxAdjust433xCal(calHandle::CalHandle,refVoltage::float64,refExcitation::float64,shuntLocation::int32)
@@ -934,36 +934,36 @@ function DAQmxAdjust4300Cal(calHandle::CalHandle,refVoltage::float64)
     ccall((:DAQmxAdjust4300Cal,NIDAQmx),int32,(CalHandle,float64),calHandle,refVoltage)
 end
 
-function DAQmxAdjust4353Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},refVal::float64)
-    ccall((:DAQmxAdjust4353Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,refVal)
+function DAQmxAdjust4353Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},refVal::float64)
+    ccall((:DAQmxAdjust4353Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,refVal)
 end
 
-function DAQmxAdjust4357Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},refVals::Ptr{float64},numRefVals::int32)
-    ccall((:DAQmxAdjust4357Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},int32),calHandle,channelNames,refVals,numRefVals)
+function DAQmxAdjust4357Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},refVals::Ptr{float64},numRefVals::int32)
+    ccall((:DAQmxAdjust4357Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},int32),calHandle,channelNames,refVals,numRefVals)
 end
 
-function DAQmxSetup4322Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},outputType::int32,outputVal::float64)
-    ccall((:DAQmxSetup4322Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32,float64),calHandle,channelNames,outputType,outputVal)
+function DAQmxSetup4322Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},outputType::int32,outputVal::float64)
+    ccall((:DAQmxSetup4322Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32,float64),calHandle,channelNames,outputType,outputVal)
 end
 
-function DAQmxAdjust4322Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},refVal::float64)
-    ccall((:DAQmxAdjust4322Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,refVal)
+function DAQmxAdjust4322Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},refVal::float64)
+    ccall((:DAQmxAdjust4322Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,refVal)
 end
 
 function DAQmxGet4322CalAdjustPoints(calHandle::CalHandle,outputType::int32,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet4322CalAdjustPoints,NIDAQmx),int32,(CalHandle,int32,Ptr{float64},uInt32),calHandle,outputType,adjustmentPoints,bufferSize)
 end
 
-function DAQmxConnectSCExpressCalAccChans(calHandle::CalHandle,channelNames::Ptr{Uint8},connection::Ptr{Uint8})
-    ccall((:DAQmxConnectSCExpressCalAccChans,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{Uint8}),calHandle,channelNames,connection)
+function DAQmxConnectSCExpressCalAccChans(calHandle::CalHandle,channelNames::Ptr{UInt8},connection::Ptr{UInt8})
+    ccall((:DAQmxConnectSCExpressCalAccChans,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{UInt8}),calHandle,channelNames,connection)
 end
 
 function DAQmxDisconnectSCExpressCalAccChans(calHandle::CalHandle)
     ccall((:DAQmxDisconnectSCExpressCalAccChans,NIDAQmx),int32,(CalHandle,),calHandle)
 end
 
-function DAQmxGetPossibleSCExpressCalAccConnections(deviceName::Ptr{Uint8},channelNames::Ptr{Uint8},connections::Ptr{Uint8},connectionsBufferSize::uInt32)
-    ccall((:DAQmxGetPossibleSCExpressCalAccConnections,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,channelNames,connections,connectionsBufferSize)
+function DAQmxGetPossibleSCExpressCalAccConnections(deviceName::Ptr{UInt8},channelNames::Ptr{UInt8},connections::Ptr{UInt8},connectionsBufferSize::uInt32)
+    ccall((:DAQmxGetPossibleSCExpressCalAccConnections,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,channelNames,connections,connectionsBufferSize)
 end
 
 function DAQmxSetSCExpressCalAccBridgeOutput(calHandle::CalHandle,voltsPerVolt::float64)
@@ -978,20 +978,20 @@ function DAQmxCSeriesSetCalTemp(calHandle::CalHandle,temperature::float64)
     ccall((:DAQmxCSeriesSetCalTemp,NIDAQmx),int32,(CalHandle,float64),calHandle,temperature)
 end
 
-function DAQmxAdjust9201Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9201Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9201Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9201Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9203CalAdjustPoints(calHandle::CalHandle,rangeMin::float64,rangeMax::float64,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9203CalAdjustPoints,NIDAQmx),int32,(CalHandle,float64,float64,Ptr{float64},uInt32),calHandle,rangeMin,rangeMax,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9203GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,value::float64)
-    ccall((:DAQmxAdjust9203GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
+function DAQmxAdjust9203GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,value::float64)
+    ccall((:DAQmxAdjust9203GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
 end
 
-function DAQmxAdjust9203OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64)
-    ccall((:DAQmxAdjust9203OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,rangeMin,rangeMax)
+function DAQmxAdjust9203OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64)
+    ccall((:DAQmxAdjust9203OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,rangeMin,rangeMax)
 end
 
 function DAQmxAdjust9205Cal(calHandle::CalHandle,value::float64)
@@ -1002,380 +1002,380 @@ function DAQmxAdjust9206Cal(calHandle::CalHandle,value::float64)
     ccall((:DAQmxAdjust9206Cal,NIDAQmx),int32,(CalHandle,float64),calHandle,value)
 end
 
-function DAQmxGet9207CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{Uint8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
-    ccall((:DAQmxGet9207CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
+function DAQmxGet9207CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{UInt8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
+    ccall((:DAQmxGet9207CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9207GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9207GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9207GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9207GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9207OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAdjust9207OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelNames)
+function DAQmxAdjust9207OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAdjust9207OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelNames)
 end
 
 function DAQmxGet9208CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9208CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9208GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9208GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9208GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9208GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9208OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAdjust9208OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelNames)
+function DAQmxAdjust9208OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAdjust9208OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelNames)
 end
 
-function DAQmxAdjust9211Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9211Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9211Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9211Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9213CalAdjustPoints(calHandle::CalHandle,rangeMin::float64,rangeMax::float64,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9213CalAdjustPoints,NIDAQmx),int32,(CalHandle,float64,float64,Ptr{float64},uInt32),calHandle,rangeMin,rangeMax,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9213Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,value::float64)
-    ccall((:DAQmxAdjust9213Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
+function DAQmxAdjust9213Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,value::float64)
+    ccall((:DAQmxAdjust9213Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
 end
 
-function DAQmxGet9214CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{Uint8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
-    ccall((:DAQmxGet9214CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
+function DAQmxGet9214CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{UInt8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
+    ccall((:DAQmxGet9214CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9214Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9214Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9214Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9214Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9215CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9215CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9215Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9215Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9215Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9215Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9217CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9217CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9217Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9217Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9217Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9217Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxSetup9219Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,measType::int32,bridgeConfig::int32)
-    ccall((:DAQmxSetup9219Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,int32,int32),calHandle,channelNames,rangeMin,rangeMax,measType,bridgeConfig)
+function DAQmxSetup9219Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,measType::int32,bridgeConfig::int32)
+    ccall((:DAQmxSetup9219Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,int32,int32),calHandle,channelNames,rangeMin,rangeMax,measType,bridgeConfig)
 end
 
 function DAQmxGet9219CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9219CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9219Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9219Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9219Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9219Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9220CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9220CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9220Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9220Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9220Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9220Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9221CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9221CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9221Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9221Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9221Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9221Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9222CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9222CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9222Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9222Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9222Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9222Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9223CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9223CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9223Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9223Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9223Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9223Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9225CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9225CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9225Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9225Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9225Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9225Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9227CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9227CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9227Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9227Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9227Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9227Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9229CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9229CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9229Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9229Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9229Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9229Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9232CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9232CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9232Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9232Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9232Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9232Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9234CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9234CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9234GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9234GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9234GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9234GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9234OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAdjust9234OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelNames)
+function DAQmxAdjust9234OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAdjust9234OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelNames)
 end
 
 function DAQmxGet9239CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9239CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9239Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9239Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9239Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9239Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9242CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9242CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9242Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxSetup9242Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxSetup9242Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxSetup9242Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9242Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9242Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9242Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9242Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9244CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9244CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9244Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxSetup9244Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxSetup9244Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxSetup9244Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9244Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9244Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9244Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9244Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9263CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9263CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9263Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9263Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9263Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9263Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9263Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9263Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9263Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9263Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9264CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9264CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9264Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9264Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9264Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9264Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9264Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9264Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9264Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9264Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9265CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9265CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9265Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9265Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9265Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9265Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9265Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9265Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9265Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9265Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9269CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9269CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9269Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9269Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9269Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9269Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9269Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9269Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9269Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9269Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxSetup1102Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1102Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1102Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1102Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1102Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1102Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1104Cal(calHandle::CalHandle,channelName::Ptr{Uint8})
-    ccall((:DAQmxSetup1104Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelName)
+function DAQmxSetup1104Cal(calHandle::CalHandle,channelName::Ptr{UInt8})
+    ccall((:DAQmxSetup1104Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelName)
 end
 
 function DAQmxAdjust1104Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1104Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1112Cal(calHandle::CalHandle,channelName::Ptr{Uint8})
-    ccall((:DAQmxSetup1112Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelName)
+function DAQmxSetup1112Cal(calHandle::CalHandle,channelName::Ptr{UInt8})
+    ccall((:DAQmxSetup1112Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelName)
 end
 
 function DAQmxAdjust1112Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1112Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1122Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1122Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1122Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1122Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1122Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1122Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1124Cal(calHandle::CalHandle,channelName::Ptr{Uint8},range::int32,dacValue::uInt32)
-    ccall((:DAQmxSetup1124Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32,uInt32),calHandle,channelName,range,dacValue)
+function DAQmxSetup1124Cal(calHandle::CalHandle,channelName::Ptr{UInt8},range::int32,dacValue::uInt32)
+    ccall((:DAQmxSetup1124Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32,uInt32),calHandle,channelName,range,dacValue)
 end
 
 function DAQmxAdjust1124Cal(calHandle::CalHandle,measOutput::float64)
     ccall((:DAQmxAdjust1124Cal,NIDAQmx),int32,(CalHandle,float64),calHandle,measOutput)
 end
 
-function DAQmxSetup1125Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1125Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1125Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1125Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1125Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1125Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1126Cal(calHandle::CalHandle,channelName::Ptr{Uint8},upperFreqLimit::float64)
-    ccall((:DAQmxSetup1126Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,upperFreqLimit)
+function DAQmxSetup1126Cal(calHandle::CalHandle,channelName::Ptr{UInt8},upperFreqLimit::float64)
+    ccall((:DAQmxSetup1126Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,upperFreqLimit)
 end
 
 function DAQmxAdjust1126Cal(calHandle::CalHandle,refFreq::float64,measOutput::float64)
     ccall((:DAQmxAdjust1126Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refFreq,measOutput)
 end
 
-function DAQmxSetup1141Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1141Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1141Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1141Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1141Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1141Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1142Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1142Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1142Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1142Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1142Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1142Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1143Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1143Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1143Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1143Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1143Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1143Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1502Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1502Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1502Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1502Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1502Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1502Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1503Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1503Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1503Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1503Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1503Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1503Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxAdjust1503CurrentCal(calHandle::CalHandle,channelName::Ptr{Uint8},measCurrent::float64)
-    ccall((:DAQmxAdjust1503CurrentCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,measCurrent)
+function DAQmxAdjust1503CurrentCal(calHandle::CalHandle,channelName::Ptr{UInt8},measCurrent::float64)
+    ccall((:DAQmxAdjust1503CurrentCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,measCurrent)
 end
 
-function DAQmxSetup1520Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1520Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1520Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1520Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1520Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1520Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1521Cal(calHandle::CalHandle,channelName::Ptr{Uint8})
-    ccall((:DAQmxSetup1521Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelName)
+function DAQmxSetup1521Cal(calHandle::CalHandle,channelName::Ptr{UInt8})
+    ccall((:DAQmxSetup1521Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelName)
 end
 
 function DAQmxAdjust1521Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1521Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup153xCal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup153xCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup153xCal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup153xCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust153xCal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust153xCal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1540Cal(calHandle::CalHandle,channelName::Ptr{Uint8},excitationVoltage::float64,excitationFreq::float64)
-    ccall((:DAQmxSetup1540Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelName,excitationVoltage,excitationFreq)
+function DAQmxSetup1540Cal(calHandle::CalHandle,channelName::Ptr{UInt8},excitationVoltage::float64,excitationFreq::float64)
+    ccall((:DAQmxSetup1540Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelName,excitationVoltage,excitationFreq)
 end
 
 function DAQmxAdjust1540Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64,inputCalSource::int32)
     ccall((:DAQmxAdjust1540Cal,NIDAQmx),int32,(CalHandle,float64,float64,int32),calHandle,refVoltage,measOutput,inputCalSource)
 end
 
-function DAQmxConfigureTEDS(physicalChannel::Ptr{Uint8},filePath::Ptr{Uint8})
-    ccall((:DAQmxConfigureTEDS,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),physicalChannel,filePath)
+function DAQmxConfigureTEDS(physicalChannel::Ptr{UInt8},filePath::Ptr{UInt8})
+    ccall((:DAQmxConfigureTEDS,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),physicalChannel,filePath)
 end
 
-function DAQmxClearTEDS(physicalChannel::Ptr{Uint8})
-    ccall((:DAQmxClearTEDS,NIDAQmx),int32,(Ptr{Uint8},),physicalChannel)
+function DAQmxClearTEDS(physicalChannel::Ptr{UInt8})
+    ccall((:DAQmxClearTEDS,NIDAQmx),int32,(Ptr{UInt8},),physicalChannel)
 end
 
-function DAQmxWriteToTEDSFromArray(physicalChannel::Ptr{Uint8},bitStream::Ptr{uInt8},arraySize::uInt32,basicTEDSOptions::int32)
-    ccall((:DAQmxWriteToTEDSFromArray,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt8},uInt32,int32),physicalChannel,bitStream,arraySize,basicTEDSOptions)
+function DAQmxWriteToTEDSFromArray(physicalChannel::Ptr{UInt8},bitStream::Ptr{uInt8},arraySize::uInt32,basicTEDSOptions::int32)
+    ccall((:DAQmxWriteToTEDSFromArray,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt8},uInt32,int32),physicalChannel,bitStream,arraySize,basicTEDSOptions)
 end
 
-function DAQmxWriteToTEDSFromFile(physicalChannel::Ptr{Uint8},filePath::Ptr{Uint8},basicTEDSOptions::int32)
-    ccall((:DAQmxWriteToTEDSFromFile,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},int32),physicalChannel,filePath,basicTEDSOptions)
+function DAQmxWriteToTEDSFromFile(physicalChannel::Ptr{UInt8},filePath::Ptr{UInt8},basicTEDSOptions::int32)
+    ccall((:DAQmxWriteToTEDSFromFile,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},int32),physicalChannel,filePath,basicTEDSOptions)
 end
 
 function DAQmxWaitForNextSampleClock(taskHandle::TaskHandle,timeout::float64,isLate::Ptr{bool32})
@@ -1390,92 +1390,92 @@ function DAQmxIsReadOrWriteLate(errorCode::int32)
     ccall((:DAQmxIsReadOrWriteLate,NIDAQmx),bool32,(int32,),errorCode)
 end
 
-function DAQmxSaveTask(taskHandle::TaskHandle,saveAs::Ptr{Uint8},author::Ptr{Uint8},options::uInt32)
-    ccall((:DAQmxSaveTask,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,saveAs,author,options)
+function DAQmxSaveTask(taskHandle::TaskHandle,saveAs::Ptr{UInt8},author::Ptr{UInt8},options::uInt32)
+    ccall((:DAQmxSaveTask,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,saveAs,author,options)
 end
 
-function DAQmxSaveGlobalChan(taskHandle::TaskHandle,channelName::Ptr{Uint8},saveAs::Ptr{Uint8},author::Ptr{Uint8},options::uInt32)
-    ccall((:DAQmxSaveGlobalChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channelName,saveAs,author,options)
+function DAQmxSaveGlobalChan(taskHandle::TaskHandle,channelName::Ptr{UInt8},saveAs::Ptr{UInt8},author::Ptr{UInt8},options::uInt32)
+    ccall((:DAQmxSaveGlobalChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channelName,saveAs,author,options)
 end
 
-function DAQmxSaveScale(scaleName::Ptr{Uint8},saveAs::Ptr{Uint8},author::Ptr{Uint8},options::uInt32)
-    ccall((:DAQmxSaveScale,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,saveAs,author,options)
+function DAQmxSaveScale(scaleName::Ptr{UInt8},saveAs::Ptr{UInt8},author::Ptr{UInt8},options::uInt32)
+    ccall((:DAQmxSaveScale,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,saveAs,author,options)
 end
 
-function DAQmxDeleteSavedTask(taskName::Ptr{Uint8})
-    ccall((:DAQmxDeleteSavedTask,NIDAQmx),int32,(Ptr{Uint8},),taskName)
+function DAQmxDeleteSavedTask(taskName::Ptr{UInt8})
+    ccall((:DAQmxDeleteSavedTask,NIDAQmx),int32,(Ptr{UInt8},),taskName)
 end
 
-function DAQmxDeleteSavedGlobalChan(channelName::Ptr{Uint8})
-    ccall((:DAQmxDeleteSavedGlobalChan,NIDAQmx),int32,(Ptr{Uint8},),channelName)
+function DAQmxDeleteSavedGlobalChan(channelName::Ptr{UInt8})
+    ccall((:DAQmxDeleteSavedGlobalChan,NIDAQmx),int32,(Ptr{UInt8},),channelName)
 end
 
-function DAQmxDeleteSavedScale(scaleName::Ptr{Uint8})
-    ccall((:DAQmxDeleteSavedScale,NIDAQmx),int32,(Ptr{Uint8},),scaleName)
+function DAQmxDeleteSavedScale(scaleName::Ptr{UInt8})
+    ccall((:DAQmxDeleteSavedScale,NIDAQmx),int32,(Ptr{UInt8},),scaleName)
 end
 
-function DAQmxSetAnalogPowerUpStatesWithOutputType(channelNames::Ptr{Uint8},stateArray::Ptr{float64},channelTypeArray::Ptr{int32},arraySize::uInt32)
-    ccall((:DAQmxSetAnalogPowerUpStatesWithOutputType,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},Ptr{int32},uInt32),channelNames,stateArray,channelTypeArray,arraySize)
+function DAQmxSetAnalogPowerUpStatesWithOutputType(channelNames::Ptr{UInt8},stateArray::Ptr{float64},channelTypeArray::Ptr{int32},arraySize::uInt32)
+    ccall((:DAQmxSetAnalogPowerUpStatesWithOutputType,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},Ptr{int32},uInt32),channelNames,stateArray,channelTypeArray,arraySize)
 end
 
-function DAQmxGetAnalogPowerUpStatesWithOutputType(channelNames::Ptr{Uint8},stateArray::Ptr{float64},channelTypeArray::Ptr{int32},arraySizePtr::Ptr{uInt32})
-    ccall((:DAQmxGetAnalogPowerUpStatesWithOutputType,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},Ptr{int32},Ptr{uInt32}),channelNames,stateArray,channelTypeArray,arraySizePtr)
+function DAQmxGetAnalogPowerUpStatesWithOutputType(channelNames::Ptr{UInt8},stateArray::Ptr{float64},channelTypeArray::Ptr{int32},arraySizePtr::Ptr{uInt32})
+    ccall((:DAQmxGetAnalogPowerUpStatesWithOutputType,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},Ptr{int32},Ptr{uInt32}),channelNames,stateArray,channelTypeArray,arraySizePtr)
 end
 
-function DAQmxSetDigitalLogicFamilyPowerUpState(deviceName::Ptr{Uint8},logicFamily::int32)
-    ccall((:DAQmxSetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{Uint8},int32),deviceName,logicFamily)
+function DAQmxSetDigitalLogicFamilyPowerUpState(deviceName::Ptr{UInt8},logicFamily::int32)
+    ccall((:DAQmxSetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{UInt8},int32),deviceName,logicFamily)
 end
 
-function DAQmxGetDigitalLogicFamilyPowerUpState(deviceName::Ptr{Uint8},logicFamily::Ptr{int32})
-    ccall((:DAQmxGetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),deviceName,logicFamily)
+function DAQmxGetDigitalLogicFamilyPowerUpState(deviceName::Ptr{UInt8},logicFamily::Ptr{int32})
+    ccall((:DAQmxGetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),deviceName,logicFamily)
 end
 
-function DAQmxAddNetworkDevice(IPAddress::Ptr{Uint8},deviceName::Ptr{Uint8},attemptReservation::bool32,timeout::float64,deviceNameOut::Ptr{Uint8},deviceNameOutBufferSize::uInt32)
-    ccall((:DAQmxAddNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},bool32,float64,Ptr{Uint8},uInt32),IPAddress,deviceName,attemptReservation,timeout,deviceNameOut,deviceNameOutBufferSize)
+function DAQmxAddNetworkDevice(IPAddress::Ptr{UInt8},deviceName::Ptr{UInt8},attemptReservation::bool32,timeout::float64,deviceNameOut::Ptr{UInt8},deviceNameOutBufferSize::uInt32)
+    ccall((:DAQmxAddNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},bool32,float64,Ptr{UInt8},uInt32),IPAddress,deviceName,attemptReservation,timeout,deviceNameOut,deviceNameOutBufferSize)
 end
 
-function DAQmxDeleteNetworkDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxDeleteNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxDeleteNetworkDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxDeleteNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxReserveNetworkDevice(deviceName::Ptr{Uint8},overrideReservation::bool32)
-    ccall((:DAQmxReserveNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,overrideReservation)
+function DAQmxReserveNetworkDevice(deviceName::Ptr{UInt8},overrideReservation::bool32)
+    ccall((:DAQmxReserveNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,overrideReservation)
 end
 
-function DAQmxUnreserveNetworkDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxUnreserveNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxUnreserveNetworkDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxUnreserveNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxAutoConfigureCDAQSyncConnections(chassisDevicesPorts::Ptr{Uint8},timeout::float64)
-    ccall((:DAQmxAutoConfigureCDAQSyncConnections,NIDAQmx),int32,(Ptr{Uint8},float64),chassisDevicesPorts,timeout)
+function DAQmxAutoConfigureCDAQSyncConnections(chassisDevicesPorts::Ptr{UInt8},timeout::float64)
+    ccall((:DAQmxAutoConfigureCDAQSyncConnections,NIDAQmx),int32,(Ptr{UInt8},float64),chassisDevicesPorts,timeout)
 end
 
-function DAQmxGetAutoConfiguredCDAQSyncConnections(portList::Ptr{Uint8},portListSize::uInt32)
-    ccall((:DAQmxGetAutoConfiguredCDAQSyncConnections,NIDAQmx),int32,(Ptr{Uint8},uInt32),portList,portListSize)
+function DAQmxGetAutoConfiguredCDAQSyncConnections(portList::Ptr{UInt8},portListSize::uInt32)
+    ccall((:DAQmxGetAutoConfiguredCDAQSyncConnections,NIDAQmx),int32,(Ptr{UInt8},uInt32),portList,portListSize)
 end
 
-function DAQmxAreConfiguredCDAQSyncPortsDisconnected(chassisDevicesPorts::Ptr{Uint8},timeout::float64,disconnectedPortsExist::Ptr{bool32})
-    ccall((:DAQmxAreConfiguredCDAQSyncPortsDisconnected,NIDAQmx),int32,(Ptr{Uint8},float64,Ptr{bool32}),chassisDevicesPorts,timeout,disconnectedPortsExist)
+function DAQmxAreConfiguredCDAQSyncPortsDisconnected(chassisDevicesPorts::Ptr{UInt8},timeout::float64,disconnectedPortsExist::Ptr{bool32})
+    ccall((:DAQmxAreConfiguredCDAQSyncPortsDisconnected,NIDAQmx),int32,(Ptr{UInt8},float64,Ptr{bool32}),chassisDevicesPorts,timeout,disconnectedPortsExist)
 end
 
-function DAQmxGetDisconnectedCDAQSyncPorts(portList::Ptr{Uint8},portListSize::uInt32)
-    ccall((:DAQmxGetDisconnectedCDAQSyncPorts,NIDAQmx),int32,(Ptr{Uint8},uInt32),portList,portListSize)
+function DAQmxGetDisconnectedCDAQSyncPorts(portList::Ptr{UInt8},portListSize::uInt32)
+    ccall((:DAQmxGetDisconnectedCDAQSyncPorts,NIDAQmx),int32,(Ptr{UInt8},uInt32),portList,portListSize)
 end
 
-function DAQmxAddCDAQSyncConnection(portList::Ptr{Uint8})
-    ccall((:DAQmxAddCDAQSyncConnection,NIDAQmx),int32,(Ptr{Uint8},),portList)
+function DAQmxAddCDAQSyncConnection(portList::Ptr{UInt8})
+    ccall((:DAQmxAddCDAQSyncConnection,NIDAQmx),int32,(Ptr{UInt8},),portList)
 end
 
-function DAQmxRemoveCDAQSyncConnection(portList::Ptr{Uint8})
-    ccall((:DAQmxRemoveCDAQSyncConnection,NIDAQmx),int32,(Ptr{Uint8},),portList)
+function DAQmxRemoveCDAQSyncConnection(portList::Ptr{UInt8})
+    ccall((:DAQmxRemoveCDAQSyncConnection,NIDAQmx),int32,(Ptr{UInt8},),portList)
 end
 
-function DAQmxGetErrorString(errorCode::int32,errorString::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetErrorString,NIDAQmx),int32,(int32,Ptr{Uint8},uInt32),errorCode,errorString,bufferSize)
+function DAQmxGetErrorString(errorCode::int32,errorString::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetErrorString,NIDAQmx),int32,(int32,Ptr{UInt8},uInt32),errorCode,errorString,bufferSize)
 end
 
-function DAQmxGetExtendedErrorInfo(errorString::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExtendedErrorInfo,NIDAQmx),int32,(Ptr{Uint8},uInt32),errorString,bufferSize)
+function DAQmxGetExtendedErrorInfo(errorString::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExtendedErrorInfo,NIDAQmx),int32,(Ptr{UInt8},uInt32),errorString,bufferSize)
 end
 
 function DAQmxGetBufInputBufSize(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -1518,5000 +1518,5000 @@ function DAQmxResetBufOutputOnbrdBufSize(taskHandle::TaskHandle)
     ccall((:DAQmxResetBufOutputOnbrdBufSize,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSelfCalSupported(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSelfCalSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSelfCalSupported(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSelfCalSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxGetSelfCalLastTemp(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSelfCalLastTemp,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetSelfCalLastTemp(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSelfCalLastTemp,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxGetExtCalRecommendedInterval(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetExtCalRecommendedInterval,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetExtCalRecommendedInterval(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetExtCalRecommendedInterval,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetExtCalLastTemp(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetExtCalLastTemp,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetExtCalLastTemp(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetExtCalLastTemp,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxGetCalUserDefinedInfo(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetCalUserDefinedInfo(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxSetCalUserDefinedInfo(deviceName::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),deviceName,data)
+function DAQmxSetCalUserDefinedInfo(deviceName::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),deviceName,data)
 end
 
-function DAQmxGetCalUserDefinedInfoMaxSize(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCalUserDefinedInfoMaxSize,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetCalUserDefinedInfoMaxSize(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCalUserDefinedInfoMaxSize,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetCalDevTemp(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCalDevTemp,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetCalDevTemp(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCalDevTemp,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxGetCalAccConnectionCount(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCalAccConnectionCount,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetCalAccConnectionCount(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCalAccConnectionCount,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxSetCalAccConnectionCount(deviceName::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCalAccConnectionCount,NIDAQmx),int32,(Ptr{Uint8},uInt32),deviceName,data)
+function DAQmxSetCalAccConnectionCount(deviceName::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCalAccConnectionCount,NIDAQmx),int32,(Ptr{UInt8},uInt32),deviceName,data)
 end
 
-function DAQmxGetCalRecommendedAccConnectionCountLimit(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCalRecommendedAccConnectionCountLimit,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetCalRecommendedAccConnectionCountLimit(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCalRecommendedAccConnectionCountLimit,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetAIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMax(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMax(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMin(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMin(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAITempUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAITempUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAITempUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAITempUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAITempUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAITempUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplCJCSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIThrmcplCJCSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplCJCSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIThrmcplCJCSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplCJCChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIThrmcplCJCChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIThrmcplCJCChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIThrmcplCJCChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxGetAIRTDType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRTDType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRTDType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDA(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDA(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDB(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDB(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDC(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDC(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRosetteStrainGageRosetteType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRosetteStrainGageRosetteType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRosetteStrainGageRosetteType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRosetteStrainGageRosetteType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRosetteStrainGageStrainChans(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIRosetteStrainGageStrainChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIRosetteStrainGageStrainChans(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIRosetteStrainGageStrainChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxGetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIIsTEDS(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIIsTEDS,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIIsTEDS(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIIsTEDS,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAITEDSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAITEDSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAITEDSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAITEDSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxGetAICoupling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICoupling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICoupling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICoupling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICoupling(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICoupling(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAITermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAITermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAITermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAITermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAITermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAITermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAtten(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAtten(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIResolution(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIResolution,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIResolution(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIResolution,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRawSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIRawSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIRawSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIRawSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRawSampJustification(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRawSampJustification,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRawSampJustification(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRawSampJustification,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalHasValidCalInfo(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIChanCalHasValidCalInfo,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalHasValidCalInfo(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIChanCalHasValidCalInfo,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIGain(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIGain(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIDevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIDevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIDevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxGetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOMax(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOMax(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOMin(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOMin(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOOutputType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOOutputType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOResolution(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOResolution,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOResolution(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOResolution,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxGetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOGain(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOGain(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAODevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAODevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAODevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxGetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDINumLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDINumLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDINumLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDINumLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDITristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDITristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDITristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDITristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDITristate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDITristate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDONumLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDONumLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDONumLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDONumLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetDOTristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOTristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOTristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOTristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOTristate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOTristate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIMax(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIMax(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIMin(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIMin(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCIOutputState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIOutputState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIOutputState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIOutputState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCITCReached(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITCReached,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITCReached(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITCReached,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCINumPossiblyInvalidSamps(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCINumPossiblyInvalidSamps,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCINumPossiblyInvalidSamps(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCINumPossiblyInvalidSamps,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOOutputType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOOutputType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOOutputState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOOutputState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOOutputState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOOutputState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseDone(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOPulseDone,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOPulseDone(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOPulseDone,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCORdyForNewVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCORdyForNewVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCORdyForNewVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCORdyForNewVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetChanType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetChanType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetChanType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetChanType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxGetChanDescr(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetChanDescr(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetChanDescr(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetChanDescr(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetChanDescr(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetChanDescr(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetChanIsGlobal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetChanIsGlobal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetChanIsGlobal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetChanIsGlobal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAIConvClkOutputTerm(taskHandle::TaskHandle)
@@ -6522,24 +6522,24 @@ function DAQmxGetExportedAIConvClkPulsePolarity(taskHandle::TaskHandle,data::Ptr
     ccall((:DAQmxGetExportedAIConvClkPulsePolarity,NIDAQmx),int32,(TaskHandle,Ptr{int32}),taskHandle,data)
 end
 
-function DAQmxGetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle)
@@ -6558,12 +6558,12 @@ function DAQmxResetExportedSampClkOutputBehavior(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSampClkOutputBehavior,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedSampClkOutputTerm(taskHandle::TaskHandle)
@@ -6594,36 +6594,36 @@ function DAQmxResetExportedSampClkPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSampClkPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAdvTrigOutputTerm(taskHandle::TaskHandle)
@@ -6658,12 +6658,12 @@ function DAQmxResetExportedAdvTrigPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedAdvTrigPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedPauseTrigOutputTerm(taskHandle::TaskHandle)
@@ -6682,12 +6682,12 @@ function DAQmxResetExportedPauseTrigLvlActiveLvl(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedPauseTrigLvlActiveLvl,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedRefTrigOutputTerm(taskHandle::TaskHandle)
@@ -6706,12 +6706,12 @@ function DAQmxResetExportedRefTrigPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedRefTrigPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedStartTrigOutputTerm(taskHandle::TaskHandle)
@@ -6730,12 +6730,12 @@ function DAQmxResetExportedStartTrigPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedStartTrigPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle)
@@ -6778,12 +6778,12 @@ function DAQmxResetExportedAdvCmpltEventPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedAdvCmpltEventPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle)
@@ -6802,12 +6802,12 @@ function DAQmxResetExportedAIHoldCmpltEventPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedAIHoldCmpltEventPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle)
@@ -6826,12 +6826,12 @@ function DAQmxResetExportedChangeDetectEventPulsePolarity(taskHandle::TaskHandle
     ccall((:DAQmxResetExportedChangeDetectEventPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle)
@@ -6874,12 +6874,12 @@ function DAQmxResetExportedCtrOutEventToggleIdleState(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedCtrOutEventToggleIdleState,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedHshkEventOutputTerm(taskHandle::TaskHandle)
@@ -6970,12 +6970,12 @@ function DAQmxResetExportedHshkEventPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedHshkEventPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle)
@@ -7018,12 +7018,12 @@ function DAQmxResetExportedRdyForXferEventDeassertCondCustomThreshold(taskHandle
     ccall((:DAQmxResetExportedRdyForXferEventDeassertCondCustomThreshold,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle)
@@ -7042,12 +7042,12 @@ function DAQmxResetExportedDataActiveEventLvlActiveLvl(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedDataActiveEventLvlActiveLvl,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle)
@@ -7066,336 +7066,336 @@ function DAQmxResetExportedRdyForStartEventLvlActiveLvl(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedRdyForStartEventLvlActiveLvl,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDevIsSimulated(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevIsSimulated,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevIsSimulated(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevIsSimulated,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevProductCategory(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevProductCategory,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevProductCategory(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevProductCategory,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevProductType(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevProductType,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevProductType(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevProductType,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevProductNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevProductNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevProductNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevProductNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevSerialNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevSerialNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevSerialNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevSerialNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevAccessoryProductTypes(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevAccessoryProductTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevAccessoryProductTypes(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevAccessoryProductTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAccessoryProductNums(device::Ptr{Uint8},data::Ptr{uInt32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAccessoryProductNums,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAccessoryProductNums(device::Ptr{UInt8},data::Ptr{uInt32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAccessoryProductNums,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAccessorySerialNums(device::Ptr{Uint8},data::Ptr{uInt32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAccessorySerialNums,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAccessorySerialNums(device::Ptr{UInt8},data::Ptr{uInt32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAccessorySerialNums,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetCarrierSerialNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCarrierSerialNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetCarrierSerialNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCarrierSerialNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevChassisModuleDevNames(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevChassisModuleDevNames,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevChassisModuleDevNames(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevChassisModuleDevNames,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAnlgTrigSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevAnlgTrigSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevAnlgTrigSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevAnlgTrigSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevDigTrigSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevDigTrigSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevDigTrigSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevDigTrigSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevAIPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevAIPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevAIPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevAIPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAISupportedMeasTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAISupportedMeasTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIMaxSingleChanRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAIMaxSingleChanRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAIMaxSingleChanRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAIMaxSingleChanRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAIMaxMultiChanRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAIMaxMultiChanRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAIMaxMultiChanRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAIMaxMultiChanRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAIMinRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAIMinRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAIMinRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAIMinRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAISimultaneousSamplingSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevAISimultaneousSamplingSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevAISimultaneousSamplingSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevAISimultaneousSamplingSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevAISampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAISampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAISampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAISampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAITrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevAITrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevAITrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevAITrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevAIVoltageRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIVoltageRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIVoltageRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIVoltageRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIVoltageIntExcitDiscreteVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIVoltageIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIVoltageIntExcitDiscreteVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIVoltageIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIVoltageIntExcitRangeVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIVoltageIntExcitRangeVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIVoltageIntExcitRangeVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIVoltageIntExcitRangeVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAICurrentRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAICurrentRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAICurrentRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAICurrentRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAICurrentIntExcitDiscreteVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAICurrentIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAICurrentIntExcitDiscreteVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAICurrentIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIBridgeRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIBridgeRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIBridgeRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIBridgeRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIResistanceRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIResistanceRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIResistanceRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIResistanceRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIFreqRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIFreqRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIFreqRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIFreqRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIGains(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIGains,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIGains(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIGains,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAICouplings(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevAICouplings,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevAICouplings(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevAICouplings,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevAILowpassCutoffFreqDiscreteVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAILowpassCutoffFreqDiscreteVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAILowpassCutoffFreqDiscreteVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAILowpassCutoffFreqDiscreteVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAILowpassCutoffFreqRangeVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAILowpassCutoffFreqRangeVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAILowpassCutoffFreqRangeVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAILowpassCutoffFreqRangeVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevAOPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevAOPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevAOPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAOSupportedOutputTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOSupportedOutputTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOSampClkSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevAOSampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevAOSampClkSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevAOSampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevAOSampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOSampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOSampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOSampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOMaxRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAOMaxRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAOMaxRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAOMaxRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAOMinRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAOMinRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAOMinRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAOMinRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAOTrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevAOTrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevAOTrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevAOTrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevAOVoltageRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOVoltageRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOVoltageRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOVoltageRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOCurrentRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOCurrentRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOCurrentRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOCurrentRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOGains(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOGains,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOGains(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOGains,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevDILines(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDILines,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDILines(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDILines,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDIPorts(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDIPorts,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDIPorts(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDIPorts,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDIMaxRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevDIMaxRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevDIMaxRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevDIMaxRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevDITrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevDITrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevDITrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevDITrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevDOLines(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDOLines,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDOLines(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDOLines,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDOPorts(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDOPorts,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDOPorts(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDOPorts,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDOMaxRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevDOMaxRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevDOMaxRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevDOMaxRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevDOTrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevDOTrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevDOTrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevDOTrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevCIPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevCIPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevCIPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevCIPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevCISupportedMeasTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCISupportedMeasTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCITrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevCITrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevCITrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevCITrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevCISampClkSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevCISampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevCISampClkSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevCISampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevCISampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCISampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCISampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCISampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCIMaxSize(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevCIMaxSize,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevCIMaxSize(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevCIMaxSize,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevCIMaxTimebase(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevCIMaxTimebase,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevCIMaxTimebase(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevCIMaxTimebase,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevCOPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevCOPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevCOPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevCOPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevCOSupportedOutputTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCOSupportedOutputTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCOSampClkSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevCOSampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevCOSampClkSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevCOSampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevCOSampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCOSampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCOSampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCOSampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCOTrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevCOTrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevCOTrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevCOTrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevCOMaxSize(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevCOMaxSize,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevCOMaxSize(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevCOMaxSize,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevCOMaxTimebase(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevCOMaxTimebase,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevCOMaxTimebase(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevCOMaxTimebase,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevTEDSHWTEDSSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevTEDSHWTEDSSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevTEDSHWTEDSSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevTEDSHWTEDSSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevNumDMAChans(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevNumDMAChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevNumDMAChans(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevNumDMAChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevBusType(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevBusType,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevBusType(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevBusType,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevPCIBusNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPCIBusNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPCIBusNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPCIBusNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevPCIDevNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPCIDevNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPCIDevNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPCIDevNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevPXIChassisNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPXIChassisNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPXIChassisNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPXIChassisNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevPXISlotNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPXISlotNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPXISlotNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPXISlotNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevCompactDAQChassisDevName(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevCompactDAQChassisDevName,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevCompactDAQChassisDevName(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevCompactDAQChassisDevName,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevCompactDAQSlotNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevCompactDAQSlotNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevCompactDAQSlotNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevCompactDAQSlotNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevTCPIPHostname(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTCPIPHostname,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTCPIPHostname(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTCPIPHostname,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevTCPIPEthernetIP(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTCPIPEthernetIP,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTCPIPEthernetIP(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTCPIPEthernetIP,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevTCPIPWirelessIP(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTCPIPWirelessIP,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTCPIPWirelessIP(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTCPIPWirelessIP,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevTerminals(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTerminals,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTerminals(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTerminals,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
 function DAQmxGetReadRelativeTo(taskHandle::TaskHandle,data::Ptr{int32})
@@ -7422,12 +7422,12 @@ function DAQmxResetReadOffset(taskHandle::TaskHandle)
     ccall((:DAQmxResetReadOffset,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetReadChannelsToRead(taskHandle::TaskHandle)
@@ -7478,12 +7478,12 @@ function DAQmxGetReadAvailSampPerChan(taskHandle::TaskHandle,data::Ptr{uInt32})
     ccall((:DAQmxGetReadAvailSampPerChan,NIDAQmx),int32,(TaskHandle,Ptr{uInt32}),taskHandle,data)
 end
 
-function DAQmxGetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetLoggingFilePath(taskHandle::TaskHandle)
@@ -7502,12 +7502,12 @@ function DAQmxResetLoggingMode(taskHandle::TaskHandle)
     ccall((:DAQmxResetLoggingMode,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetLoggingTDMSGroupName(taskHandle::TaskHandle)
@@ -7582,56 +7582,56 @@ function DAQmxGetReadCommonModeRangeErrorChansExist(taskHandle::TaskHandle,data:
     ccall((:DAQmxGetReadCommonModeRangeErrorChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadCommonModeRangeErrorChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadCommonModeRangeErrorChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadCommonModeRangeErrorChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadCommonModeRangeErrorChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOvercurrentChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOvercurrentChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOvercurrentChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOvercurrentChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOvertemperatureChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOvertemperatureChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOvertemperatureChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOvertemperatureChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOvertemperatureChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOvertemperatureChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOpenCurrentLoopChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOpenCurrentLoopChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOpenThrmcplChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOpenThrmcplChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOpenThrmcplChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOpenThrmcplChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOpenThrmcplChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOpenThrmcplChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOverloadedChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOverloadedChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOverloadedChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOverloadedChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadAccessoryInsertionOrRemovalDetected(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadAccessoryInsertionOrRemovalDetected,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadChangeDetectHasOverflowed(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -7734,132 +7734,132 @@ function DAQmxResetRealTimeWriteRecoveryMode(taskHandle::TaskHandle)
     ccall((:DAQmxResetRealTimeWriteRecoveryMode,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSwitchChanUsage(switchChannelName::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetSwitchChanUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),switchChannelName,data)
+function DAQmxGetSwitchChanUsage(switchChannelName::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetSwitchChanUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),switchChannelName,data)
 end
 
-function DAQmxSetSwitchChanUsage(switchChannelName::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetSwitchChanUsage,NIDAQmx),int32,(Ptr{Uint8},int32),switchChannelName,data)
+function DAQmxSetSwitchChanUsage(switchChannelName::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetSwitchChanUsage,NIDAQmx),int32,(Ptr{UInt8},int32),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),switchChannelName,data)
+function DAQmxGetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),switchChannelName,data)
 end
 
-function DAQmxSetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{Uint8},bool32),switchChannelName,data)
+function DAQmxSetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{UInt8},bool32),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACCarryCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACCarryCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACCarryCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACCarryCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACSwitchCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACSwitchCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACSwitchCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACSwitchCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACCarryPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACCarryPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACCarryPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACCarryPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACSwitchPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACSwitchPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACSwitchPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACSwitchPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCCarryCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCCarryCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCCarryCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCCarryCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCSwitchCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCSwitchCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCSwitchCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCSwitchCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCCarryPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCCarryPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCCarryPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCCarryPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCSwitchPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCSwitchPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCSwitchPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCSwitchPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACVoltage(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACVoltage,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACVoltage(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACVoltage,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCVoltage(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCVoltage,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCVoltage(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCVoltage,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanWireMode(switchChannelName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchChanWireMode,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),switchChannelName,data)
+function DAQmxGetSwitchChanWireMode(switchChannelName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchChanWireMode,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanBandwidth(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanBandwidth,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanBandwidth(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanBandwidth,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanImpedance(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanImpedance,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanImpedance(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanImpedance,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchDevSettlingTime(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetSwitchDevSettlingTime(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxSetSwitchDevSettlingTime(deviceName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{Uint8},float64),deviceName,data)
+function DAQmxSetSwitchDevSettlingTime(deviceName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{UInt8},float64),deviceName,data)
 end
 
-function DAQmxGetSwitchDevAutoConnAnlgBus(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSwitchDevAutoConnAnlgBus(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxSetSwitchDevAutoConnAnlgBus(deviceName::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,data)
+function DAQmxSetSwitchDevAutoConnAnlgBus(deviceName::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,data)
 end
 
-function DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,data)
+function DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,data)
 end
 
-function DAQmxGetSwitchDevSettled(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchDevSettled,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSwitchDevSettled(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchDevSettled,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevRelayList(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSwitchDevRelayList,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetSwitchDevRelayList(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSwitchDevRelayList,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxGetSwitchDevNumRelays(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumRelays,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumRelays(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumRelays,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevSwitchChanList(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSwitchDevSwitchChanList,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetSwitchDevSwitchChanList(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSwitchDevSwitchChanList,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxGetSwitchDevNumSwitchChans(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumSwitchChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumSwitchChans(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumSwitchChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevNumRows(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumRows,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumRows(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumRows,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevNumColumns(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumColumns,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumColumns(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumColumns,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevTopology(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSwitchDevTopology,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetSwitchDevTopology(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSwitchDevTopology,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxGetSwitchDevTemperature(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchDevTemperature,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetSwitchDevTemperature(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchDevTemperature,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
 function DAQmxGetSwitchScanBreakMode(taskHandle::TaskHandle,data::Ptr{int32})
@@ -7890,128 +7890,128 @@ function DAQmxGetSwitchScanWaitingForAdv(taskHandle::TaskHandle,data::Ptr{bool32
     ccall((:DAQmxGetSwitchScanWaitingForAdv,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetScaleDescr(scaleName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetScaleDescr,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,data,bufferSize)
+function DAQmxGetScaleDescr(scaleName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetScaleDescr,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,data,bufferSize)
 end
 
-function DAQmxSetScaleDescr(scaleName::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetScaleDescr,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),scaleName,data)
+function DAQmxSetScaleDescr(scaleName::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetScaleDescr,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),scaleName,data)
 end
 
-function DAQmxGetScaleScaledUnits(scaleName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetScaleScaledUnits,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,data,bufferSize)
+function DAQmxGetScaleScaledUnits(scaleName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetScaleScaledUnits,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,data,bufferSize)
 end
 
-function DAQmxSetScaleScaledUnits(scaleName::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetScaleScaledUnits,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),scaleName,data)
+function DAQmxSetScaleScaledUnits(scaleName::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetScaleScaledUnits,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),scaleName,data)
 end
 
-function DAQmxGetScalePreScaledUnits(scaleName::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetScalePreScaledUnits,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),scaleName,data)
+function DAQmxGetScalePreScaledUnits(scaleName::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetScalePreScaledUnits,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),scaleName,data)
 end
 
-function DAQmxSetScalePreScaledUnits(scaleName::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetScalePreScaledUnits,NIDAQmx),int32,(Ptr{Uint8},int32),scaleName,data)
+function DAQmxSetScalePreScaledUnits(scaleName::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetScalePreScaledUnits,NIDAQmx),int32,(Ptr{UInt8},int32),scaleName,data)
 end
 
-function DAQmxGetScaleType(scaleName::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetScaleType,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),scaleName,data)
+function DAQmxGetScaleType(scaleName::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetScaleType,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),scaleName,data)
 end
 
-function DAQmxGetScaleLinSlope(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleLinSlope,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleLinSlope(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleLinSlope,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleLinSlope(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleLinSlope,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleLinSlope(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleLinSlope,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleLinYIntercept(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleLinYIntercept,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleLinYIntercept(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleLinYIntercept,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleLinYIntercept(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleLinYIntercept,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleLinYIntercept(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleLinYIntercept,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapScaledMax(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapScaledMax,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapScaledMax(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapScaledMax,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapScaledMax(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapScaledMax,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapScaledMax(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapScaledMax,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapPreScaledMax(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapPreScaledMax(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapPreScaledMax(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapPreScaledMax(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapScaledMin(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapScaledMin,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapScaledMin(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapScaledMin,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapScaledMin(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapScaledMin,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapScaledMin(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapScaledMin,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapPreScaledMin(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapPreScaledMin(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapPreScaledMin(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapPreScaledMin(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScalePolyForwardCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScalePolyForwardCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScalePolyForwardCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScalePolyForwardCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetScalePolyReverseCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScalePolyReverseCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScalePolyReverseCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScalePolyReverseCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetScaleTableScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScaleTableScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScaleTableScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScaleTableScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScaleTableScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScaleTableScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScaleTableScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScaleTableScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetScaleTablePreScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScaleTablePreScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScaleTablePreScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScaleTablePreScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetSysGlobalChans(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysGlobalChans,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysGlobalChans(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysGlobalChans,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
-function DAQmxGetSysScales(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysScales,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysScales(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysScales,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
-function DAQmxGetSysTasks(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysTasks,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysTasks(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysTasks,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
-function DAQmxGetSysDevNames(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysDevNames,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysDevNames(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysDevNames,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
 function DAQmxGetSysNIDAQMajorVersion(data::Ptr{uInt32})
@@ -8026,20 +8026,20 @@ function DAQmxGetSysNIDAQUpdateVersion(data::Ptr{uInt32})
     ccall((:DAQmxGetSysNIDAQUpdateVersion,NIDAQmx),int32,(Ptr{uInt32},),data)
 end
 
-function DAQmxGetTaskName(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetTaskName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetTaskName(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetTaskName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetTaskChannels(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetTaskChannels,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetTaskChannels(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetTaskChannels,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetTaskNumChans(taskHandle::TaskHandle,data::Ptr{uInt32})
     ccall((:DAQmxGetTaskNumChans,NIDAQmx),int32,(TaskHandle,Ptr{uInt32}),taskHandle,data)
 end
 
-function DAQmxGetTaskDevices(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetTaskDevices,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetTaskDevices(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetTaskDevices,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetTaskNumDevices(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -8102,12 +8102,12 @@ function DAQmxGetSampClkMaxRate(taskHandle::TaskHandle,data::Ptr{float64})
     ccall((:DAQmxGetSampClkMaxRate,NIDAQmx),int32,(TaskHandle,Ptr{float64}),taskHandle,data)
 end
 
-function DAQmxGetSampClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSampClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSampClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSampClkSrc(taskHandle::TaskHandle)
@@ -8162,8 +8162,8 @@ function DAQmxResetSampClkTimebaseDiv(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkTimebaseDiv,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetSampClkTimebaseRate(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8178,12 +8178,12 @@ function DAQmxResetSampClkTimebaseRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkTimebaseRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSampClkTimebaseSrc(taskHandle::TaskHandle)
@@ -8214,8 +8214,8 @@ function DAQmxResetSampClkTimebaseMasterTimebaseDiv(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkTimebaseTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkTimebaseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkTimebaseTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkTimebaseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetSampClkDigFltrEnable(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -8242,12 +8242,12 @@ function DAQmxResetSampClkDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -8314,24 +8314,24 @@ function DAQmxResetHshkSampleInputDataWhen(taskHandle::TaskHandle)
     ccall((:DAQmxResetHshkSampleInputDataWhen,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle)
     ccall((:DAQmxResetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle)
@@ -8386,48 +8386,48 @@ function DAQmxResetAIConvRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvMaxRate(taskHandle::TaskHandle,data::Ptr{float64})
     ccall((:DAQmxGetAIConvMaxRate,NIDAQmx),int32,(TaskHandle,Ptr{float64}),taskHandle,data)
 end
 
-function DAQmxGetAIConvMaxRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvMaxRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvMaxRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvMaxRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxGetAIConvSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAIConvSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAIConvSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAIConvSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAIConvSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,deviceNames,data,bufferSize)
+function DAQmxGetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,deviceNames,data,bufferSize)
 end
 
-function DAQmxSetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,deviceNames,data)
+function DAQmxSetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvActiveEdge(taskHandle::TaskHandle,data::Ptr{int32})
@@ -8442,16 +8442,16 @@ function DAQmxResetAIConvActiveEdge(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvActiveEdge,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvTimebaseDiv(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -8466,16 +8466,16 @@ function DAQmxResetAIConvTimebaseDiv(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvTimebaseDiv,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvTimebaseSrc(taskHandle::TaskHandle,data::Ptr{int32})
@@ -8490,16 +8490,16 @@ function DAQmxResetAIConvTimebaseSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvTimebaseSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetDelayFromSampClkDelayUnits(taskHandle::TaskHandle,data::Ptr{int32})
@@ -8514,16 +8514,16 @@ function DAQmxResetDelayFromSampClkDelayUnits(taskHandle::TaskHandle)
     ccall((:DAQmxResetDelayFromSampClkDelayUnits,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,deviceNames,data)
+function DAQmxGetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,data)
+function DAQmxSetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetDelayFromSampClkDelay(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8538,16 +8538,16 @@ function DAQmxResetDelayFromSampClkDelay(taskHandle::TaskHandle)
     ccall((:DAQmxResetDelayFromSampClkDelay,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigFltrEnable(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -8562,16 +8562,16 @@ function DAQmxResetAIConvDigFltrEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigFltrMinPulseWidth(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8586,40 +8586,40 @@ function DAQmxResetAIConvDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
-function DAQmxGetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,deviceNames,data,bufferSize)
+function DAQmxGetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,deviceNames,data,bufferSize)
 end
 
-function DAQmxSetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigFltrTimebaseRate(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8634,16 +8634,16 @@ function DAQmxResetAIConvDigFltrTimebaseRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigSyncEnable(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -8658,16 +8658,16 @@ function DAQmxResetAIConvDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetMasterTimebaseRate(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8682,12 +8682,12 @@ function DAQmxResetMasterTimebaseRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetMasterTimebaseRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetMasterTimebaseSrc(taskHandle::TaskHandle)
@@ -8706,24 +8706,24 @@ function DAQmxResetRefClkRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetRefClkRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetRefClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetRefClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetRefClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetRefClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetRefClkSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetRefClkSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSyncPulseSrc(taskHandle::TaskHandle)
@@ -8762,8 +8762,8 @@ function DAQmxResetSyncPulseResetDelay(taskHandle::TaskHandle)
     ccall((:DAQmxResetSyncPulseResetDelay,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSyncPulseTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSyncPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSyncPulseTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSyncPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetSyncClkInterval(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -8802,16 +8802,16 @@ function DAQmxResetStartTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetStartTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetStartTrigTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetStartTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetStartTrigTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetStartTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeStartTrigSrc(taskHandle::TaskHandle)
@@ -8854,12 +8854,12 @@ function DAQmxResetDigEdgeStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -8890,24 +8890,24 @@ function DAQmxResetDigEdgeStartTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeStartTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternStartTrigSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternStartTrigPattern(taskHandle::TaskHandle)
@@ -8926,12 +8926,12 @@ function DAQmxResetDigPatternStartTrigWhen(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternStartTrigWhen,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle)
@@ -9010,12 +9010,12 @@ function DAQmxResetAnlgEdgeStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9046,12 +9046,12 @@ function DAQmxResetAnlgEdgeStartTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeStartTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinStartTrigSrc(taskHandle::TaskHandle)
@@ -9130,12 +9130,12 @@ function DAQmxResetAnlgWinStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9226,16 +9226,16 @@ function DAQmxResetRefTrigPretrigSamples(taskHandle::TaskHandle)
     ccall((:DAQmxResetRefTrigPretrigSamples,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetRefTrigTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetRefTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetRefTrigTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetRefTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeRefTrigSrc(taskHandle::TaskHandle)
@@ -9278,12 +9278,12 @@ function DAQmxResetDigEdgeRefTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeRefTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9314,24 +9314,24 @@ function DAQmxResetDigEdgeRefTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeRefTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternRefTrigSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternRefTrigPattern(taskHandle::TaskHandle)
@@ -9350,12 +9350,12 @@ function DAQmxResetDigPatternRefTrigWhen(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternRefTrigWhen,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle)
@@ -9434,12 +9434,12 @@ function DAQmxResetAnlgEdgeRefTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeRefTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9470,12 +9470,12 @@ function DAQmxResetAnlgEdgeRefTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeRefTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinRefTrigSrc(taskHandle::TaskHandle)
@@ -9554,12 +9554,12 @@ function DAQmxResetAnlgWinRefTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinRefTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9630,12 +9630,12 @@ function DAQmxResetAdvTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetAdvTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeAdvTrigSrc(taskHandle::TaskHandle)
@@ -9678,12 +9678,12 @@ function DAQmxResetHshkTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetHshkTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetInterlockedHshkTrigSrc(taskHandle::TaskHandle)
@@ -9714,16 +9714,16 @@ function DAQmxResetPauseTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetPauseTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetPauseTrigTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPauseTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetPauseTrigTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPauseTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle)
@@ -9802,12 +9802,12 @@ function DAQmxResetAnlgLvlPauseTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgLvlPauseTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9838,12 +9838,12 @@ function DAQmxResetAnlgLvlPauseTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgLvlPauseTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinPauseTrigSrc(taskHandle::TaskHandle)
@@ -9922,12 +9922,12 @@ function DAQmxResetAnlgWinPauseTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinPauseTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9958,12 +9958,12 @@ function DAQmxResetAnlgWinPauseTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinPauseTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigLvlPauseTrigSrc(taskHandle::TaskHandle)
@@ -10006,12 +10006,12 @@ function DAQmxResetDigLvlPauseTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigLvlPauseTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -10042,24 +10042,24 @@ function DAQmxResetDigLvlPauseTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigLvlPauseTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternPauseTrigSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternPauseTrigPattern(taskHandle::TaskHandle)
@@ -10090,16 +10090,16 @@ function DAQmxResetArmStartTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetArmStartTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetArmStartTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetArmStartTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetArmStartTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetArmStartTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle)
@@ -10142,12 +10142,12 @@ function DAQmxResetDigEdgeArmStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandl
     ccall((:DAQmxResetDigEdgeArmStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -10226,12 +10226,12 @@ function DAQmxResetWatchdogExpirTrigTrigOnNetworkConnLoss(taskHandle::TaskHandle
     ccall((:DAQmxResetWatchdogExpirTrigTrigOnNetworkConnLoss,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle)
@@ -10250,52 +10250,52 @@ function DAQmxResetDigEdgeWatchdogExpirTrigEdge(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeWatchdogExpirTrigEdge,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,lines,data)
+function DAQmxGetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,lines,data)
 end
 
-function DAQmxSetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,data)
+function DAQmxSetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,data)
 end
 
-function DAQmxResetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8})
-    ccall((:DAQmxResetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,lines)
+function DAQmxResetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8})
+    ccall((:DAQmxResetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,lines)
 end
 
-function DAQmxGetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,lines,data)
+function DAQmxGetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,lines,data)
 end
 
-function DAQmxSetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,data)
+function DAQmxSetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,data)
 end
 
-function DAQmxResetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{Uint8})
-    ccall((:DAQmxResetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,lines)
+function DAQmxResetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{UInt8})
+    ccall((:DAQmxResetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,lines)
 end
 
-function DAQmxGetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,lines,data)
+function DAQmxGetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,lines,data)
 end
 
-function DAQmxSetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,lines,data)
+function DAQmxSetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,lines,data)
 end
 
-function DAQmxResetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8})
-    ccall((:DAQmxResetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,lines)
+function DAQmxResetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8})
+    ccall((:DAQmxResetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,lines)
 end
 
-function DAQmxGetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,lines,data)
+function DAQmxGetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,lines,data)
 end
 
-function DAQmxSetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,data)
+function DAQmxSetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,data)
 end
 
-function DAQmxResetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8})
-    ccall((:DAQmxResetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,lines)
+function DAQmxResetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8})
+    ccall((:DAQmxResetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,lines)
 end
 
 function DAQmxGetWatchdogHasExpired(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -10346,40 +10346,40 @@ function DAQmxGetWriteOvercurrentChansExist(taskHandle::TaskHandle,data::Ptr{boo
     ccall((:DAQmxGetWriteOvercurrentChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOvercurrentChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOvercurrentChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteOvertemperatureChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetWriteOvertemperatureChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOvertemperatureChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOvertemperatureChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOvertemperatureChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOvertemperatureChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteOverloadedChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetWriteOverloadedChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOverloadedChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOverloadedChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteOpenCurrentLoopChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetWriteOpenCurrentLoopChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWritePowerSupplyFaultChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetWritePowerSupplyFaultChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWritePowerSupplyFaultChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWritePowerSupplyFaultChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWritePowerSupplyFaultChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWritePowerSupplyFaultChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteSpaceAvail(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -10442,184 +10442,184 @@ function DAQmxGetWriteAccessoryInsertionOrRemovalDetected(taskHandle::TaskHandle
     ccall((:DAQmxGetWriteAccessoryInsertionOrRemovalDetected,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetPhysicalChanAISupportedMeasTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanAISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanAISupportedMeasTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanAISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanAITermCfgs(physicalChannel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetPhysicalChanAITermCfgs,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAITermCfgs(physicalChannel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetPhysicalChanAITermCfgs,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAIInputSrcs(physicalChannel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPhysicalChanAIInputSrcs,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),physicalChannel,data,bufferSize)
+function DAQmxGetPhysicalChanAIInputSrcs(physicalChannel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPhysicalChanAIInputSrcs,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),physicalChannel,data,bufferSize)
 end
 
-function DAQmxGetPhysicalChanAOSupportedOutputTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanAOSupportedOutputTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanAOSupportedPowerUpOutputTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanAOSupportedPowerUpOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanAOSupportedPowerUpOutputTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanAOSupportedPowerUpOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanAOTermCfgs(physicalChannel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetPhysicalChanAOTermCfgs,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOTermCfgs(physicalChannel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetPhysicalChanAOTermCfgs,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxSetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{Uint8},bool32),physicalChannel,data)
+function DAQmxSetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{UInt8},bool32),physicalChannel,data)
 end
 
-function DAQmxResetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{Uint8})
-    ccall((:DAQmxResetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{Uint8},),physicalChannel)
+function DAQmxResetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{UInt8})
+    ccall((:DAQmxResetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{UInt8},),physicalChannel)
 end
 
-function DAQmxGetPhysicalChanAOManualControlShortDetected(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanAOManualControlShortDetected,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlShortDetected(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanAOManualControlShortDetected,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAOManualControlAmplitude(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetPhysicalChanAOManualControlAmplitude,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlAmplitude(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetPhysicalChanAOManualControlAmplitude,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAOManualControlFreq(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetPhysicalChanAOManualControlFreq,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlFreq(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetPhysicalChanAOManualControlFreq,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetAOPowerAmpChannelEnable(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetAOPowerAmpChannelEnable(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxSetAOPowerAmpChannelEnable(physicalChannel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{Uint8},bool32),physicalChannel,data)
+function DAQmxSetAOPowerAmpChannelEnable(physicalChannel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{UInt8},bool32),physicalChannel,data)
 end
 
-function DAQmxResetAOPowerAmpChannelEnable(physicalChannel::Ptr{Uint8})
-    ccall((:DAQmxResetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{Uint8},),physicalChannel)
+function DAQmxResetAOPowerAmpChannelEnable(physicalChannel::Ptr{UInt8})
+    ccall((:DAQmxResetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{UInt8},),physicalChannel)
 end
 
-function DAQmxGetAOPowerAmpScalingCoeff(physicalChannel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAOPowerAmpScalingCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetAOPowerAmpScalingCoeff(physicalChannel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAOPowerAmpScalingCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetAOPowerAmpOvercurrent(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOPowerAmpOvercurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetAOPowerAmpOvercurrent(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOPowerAmpOvercurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetAOPowerAmpGain(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOPowerAmpGain,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetAOPowerAmpGain(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOPowerAmpGain,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetAOPowerAmpOffset(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOPowerAmpOffset,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetAOPowerAmpOffset(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOPowerAmpOffset,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDIPortWidth(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanDIPortWidth,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDIPortWidth(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanDIPortWidth,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDISampClkSupported(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanDISampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDISampClkSupported(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanDISampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDISampModes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanDISampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanDISampModes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanDISampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanDIChangeDetectSupported(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanDIChangeDetectSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDIChangeDetectSupported(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanDIChangeDetectSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDOPortWidth(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanDOPortWidth,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDOPortWidth(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanDOPortWidth,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDOSampClkSupported(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanDOSampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDOSampClkSupported(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanDOSampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDOSampModes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanDOSampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanDOSampModes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanDOSampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanCISupportedMeasTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanCISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanCISupportedMeasTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanCISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanCOSupportedOutputTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanCOSupportedOutputTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanTEDSMfgID(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSMfgID,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSMfgID(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSMfgID,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSModelNum(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSModelNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSModelNum(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSModelNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSSerialNum(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSSerialNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSSerialNum(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSSerialNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSVersionNum(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSVersionNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSVersionNum(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSVersionNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSVersionLetter(physicalChannel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPhysicalChanTEDSVersionLetter,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),physicalChannel,data,bufferSize)
+function DAQmxGetPhysicalChanTEDSVersionLetter(physicalChannel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPhysicalChanTEDSVersionLetter,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),physicalChannel,data,bufferSize)
 end
 
-function DAQmxGetPhysicalChanTEDSBitStream(physicalChannel::Ptr{Uint8},data::Ptr{uInt8},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanTEDSBitStream,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt8},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanTEDSBitStream(physicalChannel::Ptr{UInt8},data::Ptr{uInt8},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanTEDSBitStream,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt8},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanTEDSTemplateIDs(physicalChannel::Ptr{Uint8},data::Ptr{uInt32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanTEDSTemplateIDs,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanTEDSTemplateIDs(physicalChannel::Ptr{UInt8},data::Ptr{uInt32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanTEDSTemplateIDs,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPersistedTaskAuthor(taskName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPersistedTaskAuthor,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),taskName,data,bufferSize)
+function DAQmxGetPersistedTaskAuthor(taskName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPersistedTaskAuthor,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),taskName,data,bufferSize)
 end
 
-function DAQmxGetPersistedTaskAllowInteractiveEditing(taskName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedTaskAllowInteractiveEditing,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),taskName,data)
+function DAQmxGetPersistedTaskAllowInteractiveEditing(taskName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedTaskAllowInteractiveEditing,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),taskName,data)
 end
 
-function DAQmxGetPersistedTaskAllowInteractiveDeletion(taskName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedTaskAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),taskName,data)
+function DAQmxGetPersistedTaskAllowInteractiveDeletion(taskName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedTaskAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),taskName,data)
 end
 
-function DAQmxGetPersistedChanAuthor(channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPersistedChanAuthor,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),channel,data,bufferSize)
+function DAQmxGetPersistedChanAuthor(channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPersistedChanAuthor,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),channel,data,bufferSize)
 end
 
-function DAQmxGetPersistedChanAllowInteractiveEditing(channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedChanAllowInteractiveEditing,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),channel,data)
+function DAQmxGetPersistedChanAllowInteractiveEditing(channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedChanAllowInteractiveEditing,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),channel,data)
 end
 
-function DAQmxGetPersistedChanAllowInteractiveDeletion(channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedChanAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),channel,data)
+function DAQmxGetPersistedChanAllowInteractiveDeletion(channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedChanAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),channel,data)
 end
 
-function DAQmxGetPersistedScaleAuthor(scaleName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPersistedScaleAuthor,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,data,bufferSize)
+function DAQmxGetPersistedScaleAuthor(scaleName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPersistedScaleAuthor,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,data,bufferSize)
 end
 
-function DAQmxGetPersistedScaleAllowInteractiveEditing(scaleName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedScaleAllowInteractiveEditing,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),scaleName,data)
+function DAQmxGetPersistedScaleAllowInteractiveEditing(scaleName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedScaleAllowInteractiveEditing,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),scaleName,data)
 end
 
-function DAQmxGetPersistedScaleAllowInteractiveDeletion(scaleName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedScaleAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),scaleName,data)
+function DAQmxGetPersistedScaleAllowInteractiveDeletion(scaleName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedScaleAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),scaleName,data)
 end
 
 function DAQmxGetSampClkTimingResponseMode(taskHandle::TaskHandle,data::Ptr{int32})

--- a/src/functions_V14.1.0.jl
+++ b/src/functions_V14.1.0.jl
@@ -2,16 +2,16 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function DAQmxLoadTask(taskName::Ptr{Uint8},taskHandle::Ptr{TaskHandle})
-    ccall((:DAQmxLoadTask,NIDAQmx),int32,(Ptr{Uint8},Ptr{TaskHandle}),taskName,taskHandle)
+function DAQmxLoadTask(taskName::Ptr{UInt8},taskHandle::Ptr{TaskHandle})
+    ccall((:DAQmxLoadTask,NIDAQmx),int32,(Ptr{UInt8},Ptr{TaskHandle}),taskName,taskHandle)
 end
 
-function DAQmxCreateTask(taskName::Ptr{Uint8},taskHandle::Ptr{TaskHandle})
-    ccall((:DAQmxCreateTask,NIDAQmx),int32,(Ptr{Uint8},Ptr{TaskHandle}),taskName,taskHandle)
+function DAQmxCreateTask(taskName::Ptr{UInt8},taskHandle::Ptr{TaskHandle})
+    ccall((:DAQmxCreateTask,NIDAQmx),int32,(Ptr{UInt8},Ptr{TaskHandle}),taskName,taskHandle)
 end
 
-function DAQmxAddGlobalChansToTask(taskHandle::TaskHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAddGlobalChansToTask,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channelNames)
+function DAQmxAddGlobalChansToTask(taskHandle::TaskHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAddGlobalChansToTask,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channelNames)
 end
 
 function DAQmxStartTask(taskHandle::TaskHandle)
@@ -38,12 +38,12 @@ function DAQmxTaskControl(taskHandle::TaskHandle,action::int32)
     ccall((:DAQmxTaskControl,NIDAQmx),int32,(TaskHandle,int32),taskHandle,action)
 end
 
-function DAQmxGetNthTaskChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{Uint8},bufferSize::int32)
-    ccall((:DAQmxGetNthTaskChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{Uint8},int32),taskHandle,index,buffer,bufferSize)
+function DAQmxGetNthTaskChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{UInt8},bufferSize::int32)
+    ccall((:DAQmxGetNthTaskChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{UInt8},int32),taskHandle,index,buffer,bufferSize)
 end
 
-function DAQmxGetNthTaskDevice(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{Uint8},bufferSize::int32)
-    ccall((:DAQmxGetNthTaskDevice,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{Uint8},int32),taskHandle,index,buffer,bufferSize)
+function DAQmxGetNthTaskDevice(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{UInt8},bufferSize::int32)
+    ccall((:DAQmxGetNthTaskDevice,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{UInt8},int32),taskHandle,index,buffer,bufferSize)
 end
 
 function DAQmxRegisterEveryNSamplesEvent(task::TaskHandle,everyNsamplesEventType::int32,nSamples::uInt32,options::uInt32,callbackFunction::DAQmxEveryNSamplesEventCallbackPtr,callbackData::Ptr{Void})
@@ -58,388 +58,388 @@ function DAQmxRegisterSignalEvent(task::TaskHandle,signalID::int32,options::uInt
     ccall((:DAQmxRegisterSignalEvent,NIDAQmx),int32,(TaskHandle,int32,uInt32,DAQmxSignalEventCallbackPtr,Ptr{Void}),task,signalID,options,callbackFunction,callbackData)
 end
 
-function DAQmxCreateAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
+function DAQmxCreateAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
 end
 
-function DAQmxCreateAIVoltageRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVoltageRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAIVoltageRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVoltageRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAICurrentRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAICurrentRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
+function DAQmxCreateAICurrentRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAICurrentRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
 end
 
-function DAQmxCreateAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,thermocoupleType::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{Uint8})
-    ccall((:DAQmxCreateAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thermocoupleType,cjcSource,cjcVal,cjcChannel)
+function DAQmxCreateAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,thermocoupleType::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{UInt8})
+    ccall((:DAQmxCreateAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thermocoupleType,cjcSource,cjcVal,cjcChannel)
 end
 
-function DAQmxCreateAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,rtdType::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,r0::float64)
-    ccall((:DAQmxCreateAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,rtdType,resistanceConfig,currentExcitSource,currentExcitVal,r0)
+function DAQmxCreateAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,rtdType::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,r0::float64)
+    ccall((:DAQmxCreateAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,rtdType,resistanceConfig,currentExcitSource,currentExcitVal,r0)
 end
 
-function DAQmxCreateAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,a::float64,b::float64,c::float64)
-    ccall((:DAQmxCreateAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,a,b,c)
+function DAQmxCreateAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,a::float64,b::float64,c::float64)
+    ccall((:DAQmxCreateAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,a,b,c)
 end
 
-function DAQmxCreateAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,a::float64,b::float64,c::float64,r1::float64)
-    ccall((:DAQmxCreateAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,a,b,c,r1)
+function DAQmxCreateAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,a::float64,b::float64,c::float64,r1::float64)
+    ccall((:DAQmxCreateAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,a,b,c,r1)
 end
 
-function DAQmxCreateAIFreqVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,thresholdLevel::float64,hysteresis::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIFreqVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thresholdLevel,hysteresis,customScaleName)
+function DAQmxCreateAIFreqVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,thresholdLevel::float64,hysteresis::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIFreqVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thresholdLevel,hysteresis,customScaleName)
 end
 
-function DAQmxCreateAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,initialBridgeVoltage::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,initialBridgeVoltage,nominalGageResistance,poissonRatio,leadWireResistance,customScaleName)
+function DAQmxCreateAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,initialBridgeVoltage::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,initialBridgeVoltage,nominalGageResistance,poissonRatio,leadWireResistance,customScaleName)
 end
 
-function DAQmxCreateAIRosetteStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,rosetteType::int32,gageOrientation::float64,rosetteMeasTypes::Ptr{int32},numRosetteMeasTypes::uInt32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64)
-    ccall((:DAQmxCreateAIRosetteStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,Ptr{int32},uInt32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,rosetteType,gageOrientation,rosetteMeasTypes,numRosetteMeasTypes,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,nominalGageResistance,poissonRatio,leadWireResistance)
+function DAQmxCreateAIRosetteStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,rosetteType::int32,gageOrientation::float64,rosetteMeasTypes::Ptr{int32},numRosetteMeasTypes::uInt32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64)
+    ccall((:DAQmxCreateAIRosetteStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,Ptr{int32},uInt32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,rosetteType,gageOrientation,rosetteMeasTypes,numRosetteMeasTypes,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,nominalGageResistance,poissonRatio,leadWireResistance)
 end
 
-function DAQmxCreateAIForceBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
+function DAQmxCreateAIForceBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIForceBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
+function DAQmxCreateAIForceBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIForceBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
+function DAQmxCreateAIForceBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIPressureBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPressureBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
+function DAQmxCreateAIPressureBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPressureBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIPressureBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPressureBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
+function DAQmxCreateAIPressureBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPressureBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIPressureBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPressureBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
+function DAQmxCreateAIPressureBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPressureBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAITorqueBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAITorqueBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
+function DAQmxCreateAITorqueBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAITorqueBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAITorqueBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAITorqueBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
+function DAQmxCreateAITorqueBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAITorqueBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAITorqueBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAITorqueBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
+function DAQmxCreateAITorqueBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAITorqueBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,customScaleName)
+function DAQmxCreateAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,customScaleName)
 end
 
-function DAQmxCreateAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,useExcitForScaling::bool32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,int32,float64,bool32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,useExcitForScaling,customScaleName)
+function DAQmxCreateAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,useExcitForScaling::bool32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,int32,float64,bool32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,useExcitForScaling,customScaleName)
 end
 
-function DAQmxCreateAITempBuiltInSensorChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32)
-    ccall((:DAQmxCreateAITempBuiltInSensorChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
+function DAQmxCreateAITempBuiltInSensorChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32)
+    ccall((:DAQmxCreateAITempBuiltInSensorChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
 end
 
-function DAQmxCreateAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIVelocityIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVelocityIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIVelocityIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVelocityIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,units::int32,micSensitivity::float64,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,float64,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,micSensitivity,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,units::int32,micSensitivity::float64,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,float64,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,micSensitivity,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateAIPosEddyCurrProxProbeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPosEddyCurrProxProbeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,customScaleName)
+function DAQmxCreateAIPosEddyCurrProxProbeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPosEddyCurrProxProbeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,customScaleName)
 end
 
-function DAQmxCreateAIDeviceTempChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32)
-    ccall((:DAQmxCreateAIDeviceTempChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
+function DAQmxCreateAIDeviceTempChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32)
+    ccall((:DAQmxCreateAIDeviceTempChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
 end
 
-function DAQmxCreateTEDSAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
+function DAQmxCreateTEDSAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateTEDSAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
+function DAQmxCreateTEDSAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,cjcSource,cjcVal,cjcChannel)
+function DAQmxCreateTEDSAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,cjcSource,cjcVal,cjcChannel)
 end
 
-function DAQmxCreateTEDSAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
-    ccall((:DAQmxCreateTEDSAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
+function DAQmxCreateTEDSAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
+    ccall((:DAQmxCreateTEDSAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
 end
 
-function DAQmxCreateTEDSAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
-    ccall((:DAQmxCreateTEDSAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
+function DAQmxCreateTEDSAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
+    ccall((:DAQmxCreateTEDSAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
 end
 
-function DAQmxCreateTEDSAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,r1::float64)
-    ccall((:DAQmxCreateTEDSAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,r1)
+function DAQmxCreateTEDSAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,r1::float64)
+    ccall((:DAQmxCreateTEDSAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,r1)
 end
 
-function DAQmxCreateTEDSAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,initialBridgeVoltage::float64,leadWireResistance::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,initialBridgeVoltage,leadWireResistance,customScaleName)
+function DAQmxCreateTEDSAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,initialBridgeVoltage::float64,leadWireResistance::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,initialBridgeVoltage,leadWireResistance,customScaleName)
 end
 
-function DAQmxCreateTEDSAIForceBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIForceBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIForceBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIForceBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIPressureBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIPressureBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIPressureBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIPressureBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAITorqueBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAITorqueBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAITorqueBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAITorqueBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,units::int32,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,units::int32,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateTEDSAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateTEDSAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateTEDSAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateAOVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAOVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAOVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAOVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAOCurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAOCurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAOCurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAOCurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAOFuncGenChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},_type::int32,freq::float64,amplitude::float64,offset::float64)
-    ccall((:DAQmxCreateAOFuncGenChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,_type,freq,amplitude,offset)
+function DAQmxCreateAOFuncGenChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},_type::int32,freq::float64,amplitude::float64,offset::float64)
+    ccall((:DAQmxCreateAOFuncGenChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,_type,freq,amplitude,offset)
 end
 
-function DAQmxCreateDIChan(taskHandle::TaskHandle,lines::Ptr{Uint8},nameToAssignToLines::Ptr{Uint8},lineGrouping::int32)
-    ccall((:DAQmxCreateDIChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
+function DAQmxCreateDIChan(taskHandle::TaskHandle,lines::Ptr{UInt8},nameToAssignToLines::Ptr{UInt8},lineGrouping::int32)
+    ccall((:DAQmxCreateDIChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
 end
 
-function DAQmxCreateDOChan(taskHandle::TaskHandle,lines::Ptr{Uint8},nameToAssignToLines::Ptr{Uint8},lineGrouping::int32)
-    ccall((:DAQmxCreateDOChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
+function DAQmxCreateDOChan(taskHandle::TaskHandle,lines::Ptr{UInt8},nameToAssignToLines::Ptr{UInt8},lineGrouping::int32)
+    ccall((:DAQmxCreateDOChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
 end
 
-function DAQmxCreateCIFreqChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIFreqChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
+function DAQmxCreateCIFreqChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIFreqChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
 end
 
-function DAQmxCreateCIPeriodChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
+function DAQmxCreateCIPeriodChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
 end
 
-function DAQmxCreateCICountEdgesChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},edge::int32,initialCount::uInt32,countDirection::int32)
-    ccall((:DAQmxCreateCICountEdgesChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,uInt32,int32),taskHandle,counter,nameToAssignToChannel,edge,initialCount,countDirection)
+function DAQmxCreateCICountEdgesChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},edge::int32,initialCount::uInt32,countDirection::int32)
+    ccall((:DAQmxCreateCICountEdgesChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,uInt32,int32),taskHandle,counter,nameToAssignToChannel,edge,initialCount,countDirection)
 end
 
-function DAQmxCreateCIPulseWidthChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,startingEdge::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIPulseWidthChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,startingEdge,customScaleName)
+function DAQmxCreateCIPulseWidthChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,startingEdge::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIPulseWidthChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,startingEdge,customScaleName)
 end
 
-function DAQmxCreateCISemiPeriodChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCISemiPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
+function DAQmxCreateCISemiPeriodChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCISemiPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateCITwoEdgeSepChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,firstEdge::int32,secondEdge::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCITwoEdgeSepChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,firstEdge,secondEdge,customScaleName)
+function DAQmxCreateCITwoEdgeSepChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,firstEdge::int32,secondEdge::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCITwoEdgeSepChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,firstEdge,secondEdge,customScaleName)
 end
 
-function DAQmxCreateCIPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32)
-    ccall((:DAQmxCreateCIPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
+function DAQmxCreateCIPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32)
+    ccall((:DAQmxCreateCIPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
 end
 
-function DAQmxCreateCIPulseChanTime(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32)
-    ccall((:DAQmxCreateCIPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
+function DAQmxCreateCIPulseChanTime(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32)
+    ccall((:DAQmxCreateCIPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
 end
 
-function DAQmxCreateCIPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},sourceTerminal::Ptr{Uint8},minVal::float64,maxVal::float64)
-    ccall((:DAQmxCreateCIPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},float64,float64),taskHandle,counter,nameToAssignToChannel,sourceTerminal,minVal,maxVal)
+function DAQmxCreateCIPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},sourceTerminal::Ptr{UInt8},minVal::float64,maxVal::float64)
+    ccall((:DAQmxCreateCIPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},float64,float64),taskHandle,counter,nameToAssignToChannel,sourceTerminal,minVal,maxVal)
 end
 
-function DAQmxCreateCILinEncoderChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,distPerPulse::float64,initialPos::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCILinEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,bool32,float64,int32,int32,float64,float64,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,distPerPulse,initialPos,customScaleName)
+function DAQmxCreateCILinEncoderChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,distPerPulse::float64,initialPos::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCILinEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,bool32,float64,int32,int32,float64,float64,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,distPerPulse,initialPos,customScaleName)
 end
 
-function DAQmxCreateCIAngEncoderChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,pulsesPerRev::uInt32,initialAngle::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIAngEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,bool32,float64,int32,int32,uInt32,float64,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,pulsesPerRev,initialAngle,customScaleName)
+function DAQmxCreateCIAngEncoderChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,pulsesPerRev::uInt32,initialAngle::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIAngEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,bool32,float64,int32,int32,uInt32,float64,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,pulsesPerRev,initialAngle,customScaleName)
 end
 
-function DAQmxCreateCIGPSTimestampChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32,syncMethod::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIGPSTimestampChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,units,syncMethod,customScaleName)
+function DAQmxCreateCIGPSTimestampChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32,syncMethod::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIGPSTimestampChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,units,syncMethod,customScaleName)
 end
 
-function DAQmxCreateCOPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32,idleState::int32,initialDelay::float64,freq::float64,dutyCycle::float64)
-    ccall((:DAQmxCreateCOPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,freq,dutyCycle)
+function DAQmxCreateCOPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32,idleState::int32,initialDelay::float64,freq::float64,dutyCycle::float64)
+    ccall((:DAQmxCreateCOPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,freq,dutyCycle)
 end
 
-function DAQmxCreateCOPulseChanTime(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32,idleState::int32,initialDelay::float64,lowTime::float64,highTime::float64)
-    ccall((:DAQmxCreateCOPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,lowTime,highTime)
+function DAQmxCreateCOPulseChanTime(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32,idleState::int32,initialDelay::float64,lowTime::float64,highTime::float64)
+    ccall((:DAQmxCreateCOPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,lowTime,highTime)
 end
 
-function DAQmxCreateCOPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},sourceTerminal::Ptr{Uint8},idleState::int32,initialDelay::int32,lowTicks::int32,highTicks::int32)
-    ccall((:DAQmxCreateCOPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},int32,int32,int32,int32),taskHandle,counter,nameToAssignToChannel,sourceTerminal,idleState,initialDelay,lowTicks,highTicks)
+function DAQmxCreateCOPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},sourceTerminal::Ptr{UInt8},idleState::int32,initialDelay::int32,lowTicks::int32,highTicks::int32)
+    ccall((:DAQmxCreateCOPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},int32,int32,int32,int32),taskHandle,counter,nameToAssignToChannel,sourceTerminal,idleState,initialDelay,lowTicks,highTicks)
 end
 
-function DAQmxGetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxGetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxSetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
-    ccall((:DAQmxSetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxSetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
+    ccall((:DAQmxSetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxGetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxGetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxSetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
-    ccall((:DAQmxSetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxSetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
+    ccall((:DAQmxSetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxResetChanAttribute(taskHandle::TaskHandle,channel::Ptr{Uint8},attribute::int32)
-    ccall((:DAQmxResetChanAttribute,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,attribute)
+function DAQmxResetChanAttribute(taskHandle::TaskHandle,channel::Ptr{UInt8},attribute::int32)
+    ccall((:DAQmxResetChanAttribute,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,attribute)
 end
 
-function DAQmxCfgSampClkTiming(taskHandle::TaskHandle,source::Ptr{Uint8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
-    ccall((:DAQmxCfgSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
+function DAQmxCfgSampClkTiming(taskHandle::TaskHandle,source::Ptr{UInt8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
+    ccall((:DAQmxCfgSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
 end
 
 function DAQmxCfgHandshakingTiming(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64)
     ccall((:DAQmxCfgHandshakingTiming,NIDAQmx),int32,(TaskHandle,int32,uInt64),taskHandle,sampleMode,sampsPerChan)
 end
 
-function DAQmxCfgBurstHandshakingTimingImportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkSrc::Ptr{Uint8},sampleClkActiveEdge::int32,pauseWhen::int32,readyEventActiveLevel::int32)
-    ccall((:DAQmxCfgBurstHandshakingTimingImportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{Uint8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkSrc,sampleClkActiveEdge,pauseWhen,readyEventActiveLevel)
+function DAQmxCfgBurstHandshakingTimingImportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkSrc::Ptr{UInt8},sampleClkActiveEdge::int32,pauseWhen::int32,readyEventActiveLevel::int32)
+    ccall((:DAQmxCfgBurstHandshakingTimingImportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{UInt8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkSrc,sampleClkActiveEdge,pauseWhen,readyEventActiveLevel)
 end
 
-function DAQmxCfgBurstHandshakingTimingExportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkOutpTerm::Ptr{Uint8},sampleClkPulsePolarity::int32,pauseWhen::int32,readyEventActiveLevel::int32)
-    ccall((:DAQmxCfgBurstHandshakingTimingExportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{Uint8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkOutpTerm,sampleClkPulsePolarity,pauseWhen,readyEventActiveLevel)
+function DAQmxCfgBurstHandshakingTimingExportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkOutpTerm::Ptr{UInt8},sampleClkPulsePolarity::int32,pauseWhen::int32,readyEventActiveLevel::int32)
+    ccall((:DAQmxCfgBurstHandshakingTimingExportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{UInt8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkOutpTerm,sampleClkPulsePolarity,pauseWhen,readyEventActiveLevel)
 end
 
-function DAQmxCfgChangeDetectionTiming(taskHandle::TaskHandle,risingEdgeChan::Ptr{Uint8},fallingEdgeChan::Ptr{Uint8},sampleMode::int32,sampsPerChan::uInt64)
-    ccall((:DAQmxCfgChangeDetectionTiming,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,uInt64),taskHandle,risingEdgeChan,fallingEdgeChan,sampleMode,sampsPerChan)
+function DAQmxCfgChangeDetectionTiming(taskHandle::TaskHandle,risingEdgeChan::Ptr{UInt8},fallingEdgeChan::Ptr{UInt8},sampleMode::int32,sampsPerChan::uInt64)
+    ccall((:DAQmxCfgChangeDetectionTiming,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,uInt64),taskHandle,risingEdgeChan,fallingEdgeChan,sampleMode,sampsPerChan)
 end
 
 function DAQmxCfgImplicitTiming(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64)
     ccall((:DAQmxCfgImplicitTiming,NIDAQmx),int32,(TaskHandle,int32,uInt64),taskHandle,sampleMode,sampsPerChan)
 end
 
-function DAQmxCfgPipelinedSampClkTiming(taskHandle::TaskHandle,source::Ptr{Uint8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
-    ccall((:DAQmxCfgPipelinedSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
+function DAQmxCfgPipelinedSampClkTiming(taskHandle::TaskHandle,source::Ptr{UInt8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
+    ccall((:DAQmxCfgPipelinedSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
 end
 
 function DAQmxResetTimingAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetTimingAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxResetTimingAttributeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},attribute::int32)
-    ccall((:DAQmxResetTimingAttributeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,attribute)
+function DAQmxResetTimingAttributeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},attribute::int32)
+    ccall((:DAQmxResetTimingAttributeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,attribute)
 end
 
 function DAQmxDisableStartTrig(taskHandle::TaskHandle)
     ccall((:DAQmxDisableStartTrig,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxCfgDigEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerEdge::int32)
-    ccall((:DAQmxCfgDigEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,triggerSource,triggerEdge)
+function DAQmxCfgDigEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerEdge::int32)
+    ccall((:DAQmxCfgDigEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,triggerSource,triggerEdge)
 end
 
-function DAQmxCfgAnlgEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerSlope::int32,triggerLevel::float64)
-    ccall((:DAQmxCfgAnlgEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64),taskHandle,triggerSource,triggerSlope,triggerLevel)
+function DAQmxCfgAnlgEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerSlope::int32,triggerLevel::float64)
+    ccall((:DAQmxCfgAnlgEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64),taskHandle,triggerSource,triggerSlope,triggerLevel)
 end
 
-function DAQmxCfgAnlgWindowStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerWhen::int32,windowTop::float64,windowBottom::float64)
-    ccall((:DAQmxCfgAnlgWindowStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64,float64),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom)
+function DAQmxCfgAnlgWindowStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerWhen::int32,windowTop::float64,windowBottom::float64)
+    ccall((:DAQmxCfgAnlgWindowStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64,float64),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom)
 end
 
-function DAQmxCfgDigPatternStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerPattern::Ptr{Uint8},triggerWhen::int32)
-    ccall((:DAQmxCfgDigPatternStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,triggerSource,triggerPattern,triggerWhen)
+function DAQmxCfgDigPatternStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerPattern::Ptr{UInt8},triggerWhen::int32)
+    ccall((:DAQmxCfgDigPatternStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,triggerSource,triggerPattern,triggerWhen)
 end
 
 function DAQmxDisableRefTrig(taskHandle::TaskHandle)
     ccall((:DAQmxDisableRefTrig,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxCfgDigEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerEdge::int32,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgDigEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,uInt32),taskHandle,triggerSource,triggerEdge,pretriggerSamples)
+function DAQmxCfgDigEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerEdge::int32,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgDigEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,uInt32),taskHandle,triggerSource,triggerEdge,pretriggerSamples)
 end
 
-function DAQmxCfgAnlgEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerSlope::int32,triggerLevel::float64,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgAnlgEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64,uInt32),taskHandle,triggerSource,triggerSlope,triggerLevel,pretriggerSamples)
+function DAQmxCfgAnlgEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerSlope::int32,triggerLevel::float64,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgAnlgEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64,uInt32),taskHandle,triggerSource,triggerSlope,triggerLevel,pretriggerSamples)
 end
 
-function DAQmxCfgAnlgWindowRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerWhen::int32,windowTop::float64,windowBottom::float64,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgAnlgWindowRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64,float64,uInt32),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom,pretriggerSamples)
+function DAQmxCfgAnlgWindowRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerWhen::int32,windowTop::float64,windowBottom::float64,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgAnlgWindowRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64,float64,uInt32),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom,pretriggerSamples)
 end
 
-function DAQmxCfgDigPatternRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerPattern::Ptr{Uint8},triggerWhen::int32,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgDigPatternRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,uInt32),taskHandle,triggerSource,triggerPattern,triggerWhen,pretriggerSamples)
+function DAQmxCfgDigPatternRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerPattern::Ptr{UInt8},triggerWhen::int32,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgDigPatternRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,uInt32),taskHandle,triggerSource,triggerPattern,triggerWhen,pretriggerSamples)
 end
 
 function DAQmxDisableAdvTrig(taskHandle::TaskHandle)
     ccall((:DAQmxDisableAdvTrig,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxCfgDigEdgeAdvTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerEdge::int32)
-    ccall((:DAQmxCfgDigEdgeAdvTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,triggerSource,triggerEdge)
+function DAQmxCfgDigEdgeAdvTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerEdge::int32)
+    ccall((:DAQmxCfgDigEdgeAdvTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,triggerSource,triggerEdge)
 end
 
 function DAQmxResetTrigAttribute(taskHandle::TaskHandle,attribute::int32)
@@ -538,20 +538,20 @@ function DAQmxReadRaw(taskHandle::TaskHandle,numSampsPerChan::int32,timeout::flo
     ccall((:DAQmxReadRaw,NIDAQmx),int32,(TaskHandle,int32,float64,Ptr{Void},uInt32,Ptr{int32},Ptr{int32},Ptr{bool32}),taskHandle,numSampsPerChan,timeout,readArray,arraySizeInBytes,sampsRead,numBytesPerSamp,reserved)
 end
 
-function DAQmxGetNthTaskReadChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{Uint8},bufferSize::int32)
-    ccall((:DAQmxGetNthTaskReadChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{Uint8},int32),taskHandle,index,buffer,bufferSize)
+function DAQmxGetNthTaskReadChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{UInt8},bufferSize::int32)
+    ccall((:DAQmxGetNthTaskReadChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{UInt8},int32),taskHandle,index,buffer,bufferSize)
 end
 
 function DAQmxResetReadAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetReadAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxConfigureLogging(taskHandle::TaskHandle,filePath::Ptr{Uint8},loggingMode::int32,groupName::Ptr{Uint8},operation::int32)
-    ccall((:DAQmxConfigureLogging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,Ptr{Uint8},int32),taskHandle,filePath,loggingMode,groupName,operation)
+function DAQmxConfigureLogging(taskHandle::TaskHandle,filePath::Ptr{UInt8},loggingMode::int32,groupName::Ptr{UInt8},operation::int32)
+    ccall((:DAQmxConfigureLogging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,Ptr{UInt8},int32),taskHandle,filePath,loggingMode,groupName,operation)
 end
 
-function DAQmxStartNewFile(taskHandle::TaskHandle,filePath::Ptr{Uint8})
-    ccall((:DAQmxStartNewFile,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,filePath)
+function DAQmxStartNewFile(taskHandle::TaskHandle,filePath::Ptr{UInt8})
+    ccall((:DAQmxStartNewFile,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,filePath)
 end
 
 function DAQmxWriteAnalogF64(taskHandle::TaskHandle,numSampsPerChan::int32,autoStart::bool32,timeout::float64,dataLayout::bool32,writeArray::Ptr{float64},sampsPerChanWritten::Ptr{int32},reserved::Ptr{bool32})
@@ -630,28 +630,28 @@ function DAQmxResetWriteAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetWriteAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxExportSignal(taskHandle::TaskHandle,signalID::int32,outputTerminal::Ptr{Uint8})
-    ccall((:DAQmxExportSignal,NIDAQmx),int32,(TaskHandle,int32,Ptr{Uint8}),taskHandle,signalID,outputTerminal)
+function DAQmxExportSignal(taskHandle::TaskHandle,signalID::int32,outputTerminal::Ptr{UInt8})
+    ccall((:DAQmxExportSignal,NIDAQmx),int32,(TaskHandle,int32,Ptr{UInt8}),taskHandle,signalID,outputTerminal)
 end
 
 function DAQmxResetExportedSignalAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetExportedSignalAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxCreateLinScale(name::Ptr{Uint8},slope::float64,yIntercept::float64,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreateLinScale,NIDAQmx),int32,(Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),name,slope,yIntercept,preScaledUnits,scaledUnits)
+function DAQmxCreateLinScale(name::Ptr{UInt8},slope::float64,yIntercept::float64,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreateLinScale,NIDAQmx),int32,(Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),name,slope,yIntercept,preScaledUnits,scaledUnits)
 end
 
-function DAQmxCreateMapScale(name::Ptr{Uint8},prescaledMin::float64,prescaledMax::float64,scaledMin::float64,scaledMax::float64,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreateMapScale,NIDAQmx),int32,(Ptr{Uint8},float64,float64,float64,float64,int32,Ptr{Uint8}),name,prescaledMin,prescaledMax,scaledMin,scaledMax,preScaledUnits,scaledUnits)
+function DAQmxCreateMapScale(name::Ptr{UInt8},prescaledMin::float64,prescaledMax::float64,scaledMin::float64,scaledMax::float64,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreateMapScale,NIDAQmx),int32,(Ptr{UInt8},float64,float64,float64,float64,int32,Ptr{UInt8}),name,prescaledMin,prescaledMax,scaledMin,scaledMax,preScaledUnits,scaledUnits)
 end
 
-function DAQmxCreatePolynomialScale(name::Ptr{Uint8},forwardCoeffs::Ptr{float64},numForwardCoeffsIn::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreatePolynomialScale,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{Uint8}),name,forwardCoeffs,numForwardCoeffsIn,reverseCoeffs,numReverseCoeffsIn,preScaledUnits,scaledUnits)
+function DAQmxCreatePolynomialScale(name::Ptr{UInt8},forwardCoeffs::Ptr{float64},numForwardCoeffsIn::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreatePolynomialScale,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{UInt8}),name,forwardCoeffs,numForwardCoeffsIn,reverseCoeffs,numReverseCoeffsIn,preScaledUnits,scaledUnits)
 end
 
-function DAQmxCreateTableScale(name::Ptr{Uint8},prescaledVals::Ptr{float64},numPrescaledValsIn::uInt32,scaledVals::Ptr{float64},numScaledValsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreateTableScale,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{Uint8}),name,prescaledVals,numPrescaledValsIn,scaledVals,numScaledValsIn,preScaledUnits,scaledUnits)
+function DAQmxCreateTableScale(name::Ptr{UInt8},prescaledVals::Ptr{float64},numPrescaledValsIn::uInt32,scaledVals::Ptr{float64},numScaledValsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreateTableScale,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{UInt8}),name,prescaledVals,numPrescaledValsIn,scaledVals,numScaledValsIn,preScaledUnits,scaledUnits)
 end
 
 function DAQmxCalculateReversePolyCoeff(forwardCoeffs::Ptr{float64},numForwardCoeffsIn::uInt32,minValX::float64,maxValX::float64,numPointsToCompute::int32,reversePolyOrder::int32,reverseCoeffs::Ptr{float64})
@@ -674,68 +674,68 @@ function DAQmxResetBufferAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetBufferAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxSwitchCreateScanList(scanList::Ptr{Uint8},taskHandle::Ptr{TaskHandle})
-    ccall((:DAQmxSwitchCreateScanList,NIDAQmx),int32,(Ptr{Uint8},Ptr{TaskHandle}),scanList,taskHandle)
+function DAQmxSwitchCreateScanList(scanList::Ptr{UInt8},taskHandle::Ptr{TaskHandle})
+    ccall((:DAQmxSwitchCreateScanList,NIDAQmx),int32,(Ptr{UInt8},Ptr{TaskHandle}),scanList,taskHandle)
 end
 
-function DAQmxSwitchConnect(switchChannel1::Ptr{Uint8},switchChannel2::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchConnect,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},bool32),switchChannel1,switchChannel2,waitForSettling)
+function DAQmxSwitchConnect(switchChannel1::Ptr{UInt8},switchChannel2::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchConnect,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},bool32),switchChannel1,switchChannel2,waitForSettling)
 end
 
-function DAQmxSwitchConnectMulti(connectionList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchConnectMulti,NIDAQmx),int32,(Ptr{Uint8},bool32),connectionList,waitForSettling)
+function DAQmxSwitchConnectMulti(connectionList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchConnectMulti,NIDAQmx),int32,(Ptr{UInt8},bool32),connectionList,waitForSettling)
 end
 
-function DAQmxSwitchDisconnect(switchChannel1::Ptr{Uint8},switchChannel2::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchDisconnect,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},bool32),switchChannel1,switchChannel2,waitForSettling)
+function DAQmxSwitchDisconnect(switchChannel1::Ptr{UInt8},switchChannel2::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchDisconnect,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},bool32),switchChannel1,switchChannel2,waitForSettling)
 end
 
-function DAQmxSwitchDisconnectMulti(connectionList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchDisconnectMulti,NIDAQmx),int32,(Ptr{Uint8},bool32),connectionList,waitForSettling)
+function DAQmxSwitchDisconnectMulti(connectionList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchDisconnectMulti,NIDAQmx),int32,(Ptr{UInt8},bool32),connectionList,waitForSettling)
 end
 
-function DAQmxSwitchDisconnectAll(deviceName::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchDisconnectAll,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,waitForSettling)
+function DAQmxSwitchDisconnectAll(deviceName::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchDisconnectAll,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,waitForSettling)
 end
 
-function DAQmxSwitchSetTopologyAndReset(deviceName::Ptr{Uint8},newTopology::Ptr{Uint8})
-    ccall((:DAQmxSwitchSetTopologyAndReset,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),deviceName,newTopology)
+function DAQmxSwitchSetTopologyAndReset(deviceName::Ptr{UInt8},newTopology::Ptr{UInt8})
+    ccall((:DAQmxSwitchSetTopologyAndReset,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),deviceName,newTopology)
 end
 
-function DAQmxSwitchFindPath(switchChannel1::Ptr{Uint8},switchChannel2::Ptr{Uint8},path::Ptr{Uint8},pathBufferSize::uInt32,pathStatus::Ptr{int32})
-    ccall((:DAQmxSwitchFindPath,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32,Ptr{int32}),switchChannel1,switchChannel2,path,pathBufferSize,pathStatus)
+function DAQmxSwitchFindPath(switchChannel1::Ptr{UInt8},switchChannel2::Ptr{UInt8},path::Ptr{UInt8},pathBufferSize::uInt32,pathStatus::Ptr{int32})
+    ccall((:DAQmxSwitchFindPath,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32,Ptr{int32}),switchChannel1,switchChannel2,path,pathBufferSize,pathStatus)
 end
 
-function DAQmxSwitchOpenRelays(relayList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchOpenRelays,NIDAQmx),int32,(Ptr{Uint8},bool32),relayList,waitForSettling)
+function DAQmxSwitchOpenRelays(relayList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchOpenRelays,NIDAQmx),int32,(Ptr{UInt8},bool32),relayList,waitForSettling)
 end
 
-function DAQmxSwitchCloseRelays(relayList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchCloseRelays,NIDAQmx),int32,(Ptr{Uint8},bool32),relayList,waitForSettling)
+function DAQmxSwitchCloseRelays(relayList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchCloseRelays,NIDAQmx),int32,(Ptr{UInt8},bool32),relayList,waitForSettling)
 end
 
-function DAQmxSwitchGetSingleRelayCount(relayName::Ptr{Uint8},count::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetSingleRelayCount,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),relayName,count)
+function DAQmxSwitchGetSingleRelayCount(relayName::Ptr{UInt8},count::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetSingleRelayCount,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),relayName,count)
 end
 
-function DAQmxSwitchGetMultiRelayCount(relayList::Ptr{Uint8},count::Ptr{uInt32},countArraySize::uInt32,numRelayCountsRead::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetMultiRelayCount,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,count,countArraySize,numRelayCountsRead)
+function DAQmxSwitchGetMultiRelayCount(relayList::Ptr{UInt8},count::Ptr{uInt32},countArraySize::uInt32,numRelayCountsRead::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetMultiRelayCount,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,count,countArraySize,numRelayCountsRead)
 end
 
-function DAQmxSwitchGetSingleRelayPos(relayName::Ptr{Uint8},relayPos::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetSingleRelayPos,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),relayName,relayPos)
+function DAQmxSwitchGetSingleRelayPos(relayName::Ptr{UInt8},relayPos::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetSingleRelayPos,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),relayName,relayPos)
 end
 
-function DAQmxSwitchGetMultiRelayPos(relayList::Ptr{Uint8},relayPos::Ptr{uInt32},relayPosArraySize::uInt32,numRelayPossRead::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetMultiRelayPos,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,relayPos,relayPosArraySize,numRelayPossRead)
+function DAQmxSwitchGetMultiRelayPos(relayList::Ptr{UInt8},relayPos::Ptr{uInt32},relayPosArraySize::uInt32,numRelayPossRead::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetMultiRelayPos,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,relayPos,relayPosArraySize,numRelayPossRead)
 end
 
-function DAQmxSwitchWaitForSettling(deviceName::Ptr{Uint8})
-    ccall((:DAQmxSwitchWaitForSettling,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxSwitchWaitForSettling(deviceName::Ptr{UInt8})
+    ccall((:DAQmxSwitchWaitForSettling,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxGetSwitchChanAttribute(switchChannelName::Ptr{Uint8},attribute::int32,value::Ptr{Void})
-    ccall((:DAQmxGetSwitchChanAttribute,NIDAQmx),int32,(Ptr{Uint8},int32,Ptr{Void}),switchChannelName,attribute,value)
+function DAQmxGetSwitchChanAttribute(switchChannelName::Ptr{UInt8},attribute::int32,value::Ptr{Void})
+    ccall((:DAQmxGetSwitchChanAttribute,NIDAQmx),int32,(Ptr{UInt8},int32,Ptr{Void}),switchChannelName,attribute,value)
 end
 
 function DAQmxGetSwitchScanAttribute(taskHandle::TaskHandle,attribute::int32,value::Ptr{Void})
@@ -746,84 +746,84 @@ function DAQmxResetSwitchScanAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetSwitchScanAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxConnectTerms(sourceTerminal::Ptr{Uint8},destinationTerminal::Ptr{Uint8},signalModifiers::int32)
-    ccall((:DAQmxConnectTerms,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},int32),sourceTerminal,destinationTerminal,signalModifiers)
+function DAQmxConnectTerms(sourceTerminal::Ptr{UInt8},destinationTerminal::Ptr{UInt8},signalModifiers::int32)
+    ccall((:DAQmxConnectTerms,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},int32),sourceTerminal,destinationTerminal,signalModifiers)
 end
 
-function DAQmxDisconnectTerms(sourceTerminal::Ptr{Uint8},destinationTerminal::Ptr{Uint8})
-    ccall((:DAQmxDisconnectTerms,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),sourceTerminal,destinationTerminal)
+function DAQmxDisconnectTerms(sourceTerminal::Ptr{UInt8},destinationTerminal::Ptr{UInt8})
+    ccall((:DAQmxDisconnectTerms,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),sourceTerminal,destinationTerminal)
 end
 
-function DAQmxTristateOutputTerm(outputTerminal::Ptr{Uint8})
-    ccall((:DAQmxTristateOutputTerm,NIDAQmx),int32,(Ptr{Uint8},),outputTerminal)
+function DAQmxTristateOutputTerm(outputTerminal::Ptr{UInt8})
+    ccall((:DAQmxTristateOutputTerm,NIDAQmx),int32,(Ptr{UInt8},),outputTerminal)
 end
 
-function DAQmxResetDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxResetDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxResetDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxResetDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxSelfTestDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxSelfTestDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxSelfTestDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxSelfTestDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxCreateWatchdogTimerTaskEx(deviceName::Ptr{Uint8},taskName::Ptr{Uint8},taskHandle::Ptr{TaskHandle},timeout::float64)
-    ccall((:DAQmxCreateWatchdogTimerTaskEx,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{TaskHandle},float64),deviceName,taskName,taskHandle,timeout)
+function DAQmxCreateWatchdogTimerTaskEx(deviceName::Ptr{UInt8},taskName::Ptr{UInt8},taskHandle::Ptr{TaskHandle},timeout::float64)
+    ccall((:DAQmxCreateWatchdogTimerTaskEx,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{TaskHandle},float64),deviceName,taskName,taskHandle,timeout)
 end
 
 function DAQmxControlWatchdogTask(taskHandle::TaskHandle,action::int32)
     ccall((:DAQmxControlWatchdogTask,NIDAQmx),int32,(TaskHandle,int32),taskHandle,action)
 end
 
-function DAQmxCfgWatchdogAOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{Uint8},expirStateArray::Ptr{float64},outputTypeArray::Ptr{int32},arraySize::uInt32)
-    ccall((:DAQmxCfgWatchdogAOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,outputTypeArray,arraySize)
+function DAQmxCfgWatchdogAOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{UInt8},expirStateArray::Ptr{float64},outputTypeArray::Ptr{int32},arraySize::uInt32)
+    ccall((:DAQmxCfgWatchdogAOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,outputTypeArray,arraySize)
 end
 
-function DAQmxCfgWatchdogCOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{Uint8},expirStateArray::Ptr{int32},arraySize::uInt32)
-    ccall((:DAQmxCfgWatchdogCOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,arraySize)
+function DAQmxCfgWatchdogCOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{UInt8},expirStateArray::Ptr{int32},arraySize::uInt32)
+    ccall((:DAQmxCfgWatchdogCOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,arraySize)
 end
 
-function DAQmxCfgWatchdogDOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{Uint8},expirStateArray::Ptr{int32},arraySize::uInt32)
-    ccall((:DAQmxCfgWatchdogDOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,arraySize)
+function DAQmxCfgWatchdogDOExpirStates(taskHandle::TaskHandle,channelNames::Ptr{UInt8},expirStateArray::Ptr{int32},arraySize::uInt32)
+    ccall((:DAQmxCfgWatchdogDOExpirStates,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32},uInt32),taskHandle,channelNames,expirStateArray,arraySize)
 end
 
-function DAQmxResetWatchdogAttribute(taskHandle::TaskHandle,lines::Ptr{Uint8},attribute::int32)
-    ccall((:DAQmxResetWatchdogAttribute,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,attribute)
+function DAQmxResetWatchdogAttribute(taskHandle::TaskHandle,lines::Ptr{UInt8},attribute::int32)
+    ccall((:DAQmxResetWatchdogAttribute,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,attribute)
 end
 
-function DAQmxSelfCal(deviceName::Ptr{Uint8})
-    ccall((:DAQmxSelfCal,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxSelfCal(deviceName::Ptr{UInt8})
+    ccall((:DAQmxSelfCal,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxPerformBridgeOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxPerformBridgeOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxPerformBridgeOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxPerformBridgeOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxPerformBridgeOffsetNullingCalEx(taskHandle::TaskHandle,channel::Ptr{Uint8},skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformBridgeOffsetNullingCalEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,skipUnsupportedChannels)
+function DAQmxPerformBridgeOffsetNullingCalEx(taskHandle::TaskHandle,channel::Ptr{UInt8},skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformBridgeOffsetNullingCalEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,skipUnsupportedChannels)
 end
 
-function DAQmxPerformThrmcplLeadOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{Uint8},skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformThrmcplLeadOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,skipUnsupportedChannels)
+function DAQmxPerformThrmcplLeadOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{UInt8},skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformThrmcplLeadOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,skipUnsupportedChannels)
 end
 
-function DAQmxPerformStrainShuntCal(taskHandle::TaskHandle,channel::Ptr{Uint8},shuntResistorValue::float64,shuntResistorLocation::int32,skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformStrainShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,skipUnsupportedChannels)
+function DAQmxPerformStrainShuntCal(taskHandle::TaskHandle,channel::Ptr{UInt8},shuntResistorValue::float64,shuntResistorLocation::int32,skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformStrainShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,skipUnsupportedChannels)
 end
 
-function DAQmxPerformBridgeShuntCal(taskHandle::TaskHandle,channel::Ptr{Uint8},shuntResistorValue::float64,shuntResistorLocation::int32,bridgeResistance::float64,skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformBridgeShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,float64,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,bridgeResistance,skipUnsupportedChannels)
+function DAQmxPerformBridgeShuntCal(taskHandle::TaskHandle,channel::Ptr{UInt8},shuntResistorValue::float64,shuntResistorLocation::int32,bridgeResistance::float64,skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformBridgeShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,float64,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,bridgeResistance,skipUnsupportedChannels)
 end
 
-function DAQmxGetSelfCalLastDateAndTime(deviceName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetSelfCalLastDateAndTime,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
+function DAQmxGetSelfCalLastDateAndTime(deviceName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetSelfCalLastDateAndTime,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
 end
 
-function DAQmxGetExtCalLastDateAndTime(deviceName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetExtCalLastDateAndTime,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
+function DAQmxGetExtCalLastDateAndTime(deviceName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetExtCalLastDateAndTime,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
 end
 
-function DAQmxRestoreLastExtCalConst(deviceName::Ptr{Uint8})
-    ccall((:DAQmxRestoreLastExtCalConst,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxRestoreLastExtCalConst(deviceName::Ptr{UInt8})
+    ccall((:DAQmxRestoreLastExtCalConst,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
 function DAQmxESeriesCalAdjust(calHandle::CalHandle,referenceVoltage::float64)
@@ -850,20 +850,20 @@ function DAQmxXSeriesCalAdjust(calHandle::CalHandle,referenceVoltage::float64)
     ccall((:DAQmxXSeriesCalAdjust,NIDAQmx),int32,(CalHandle,float64),calHandle,referenceVoltage)
 end
 
-function DAQmxDeviceSupportsCal(deviceName::Ptr{Uint8},calSupported::Ptr{bool32})
-    ccall((:DAQmxDeviceSupportsCal,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,calSupported)
+function DAQmxDeviceSupportsCal(deviceName::Ptr{UInt8},calSupported::Ptr{bool32})
+    ccall((:DAQmxDeviceSupportsCal,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,calSupported)
 end
 
-function DAQmxInitExtCal(deviceName::Ptr{Uint8},password::Ptr{Uint8},calHandle::Ptr{CalHandle})
-    ccall((:DAQmxInitExtCal,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{CalHandle}),deviceName,password,calHandle)
+function DAQmxInitExtCal(deviceName::Ptr{UInt8},password::Ptr{UInt8},calHandle::Ptr{CalHandle})
+    ccall((:DAQmxInitExtCal,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{CalHandle}),deviceName,password,calHandle)
 end
 
 function DAQmxCloseExtCal(calHandle::CalHandle,action::int32)
     ccall((:DAQmxCloseExtCal,NIDAQmx),int32,(CalHandle,int32),calHandle,action)
 end
 
-function DAQmxChangeExtCalPassword(deviceName::Ptr{Uint8},password::Ptr{Uint8},newPassword::Ptr{Uint8})
-    ccall((:DAQmxChangeExtCalPassword,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8}),deviceName,password,newPassword)
+function DAQmxChangeExtCalPassword(deviceName::Ptr{UInt8},password::Ptr{UInt8},newPassword::Ptr{UInt8})
+    ccall((:DAQmxChangeExtCalPassword,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8}),deviceName,password,newPassword)
 end
 
 function DAQmxDSASetCalTemp(calHandle::CalHandle,temperature::float64)
@@ -886,8 +886,8 @@ function DAQmxAdjustDSAAOCal(calHandle::CalHandle,channel::uInt32,requestedLowVo
     ccall((:DAQmxAdjustDSAAOCal,NIDAQmx),int32,(CalHandle,uInt32,float64,float64,float64,float64,float64),calHandle,channel,requestedLowVoltage,actualLowVoltage,requestedHighVoltage,actualHighVoltage,gainSetting)
 end
 
-function DAQmxAdjust4610Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64,offset::float64)
-    ccall((:DAQmxAdjust4610Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelName,gain,offset)
+function DAQmxAdjust4610Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64,offset::float64)
+    ccall((:DAQmxAdjust4610Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelName,gain,offset)
 end
 
 function DAQmxAdjustDSATimebaseCal(calHandle::CalHandle,referenceFrequency::float64)
@@ -906,32 +906,32 @@ function DAQmxAdjustTIOTimebaseCal(calHandle::CalHandle,referenceFrequency::floa
     ccall((:DAQmxAdjustTIOTimebaseCal,NIDAQmx),int32,(CalHandle,float64),calHandle,referenceFrequency)
 end
 
-function DAQmxAdjust4204Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},lowPassFreq::float64,trackHoldEnabled::bool32,inputVal::float64)
-    ccall((:DAQmxAdjust4204Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,bool32,float64),calHandle,channelNames,lowPassFreq,trackHoldEnabled,inputVal)
+function DAQmxAdjust4204Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},lowPassFreq::float64,trackHoldEnabled::bool32,inputVal::float64)
+    ccall((:DAQmxAdjust4204Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,bool32,float64),calHandle,channelNames,lowPassFreq,trackHoldEnabled,inputVal)
 end
 
-function DAQmxAdjust4220Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},gain::float64,inputVal::float64)
-    ccall((:DAQmxAdjust4220Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,gain,inputVal)
+function DAQmxAdjust4220Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},gain::float64,inputVal::float64)
+    ccall((:DAQmxAdjust4220Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,gain,inputVal)
 end
 
-function DAQmxAdjust4224Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},gain::float64,inputVal::float64)
-    ccall((:DAQmxAdjust4224Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,gain,inputVal)
+function DAQmxAdjust4224Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},gain::float64,inputVal::float64)
+    ccall((:DAQmxAdjust4224Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,gain,inputVal)
 end
 
-function DAQmxAdjust4225Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},gain::float64,inputVal::float64)
-    ccall((:DAQmxAdjust4225Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,gain,inputVal)
+function DAQmxAdjust4225Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},gain::float64,inputVal::float64)
+    ccall((:DAQmxAdjust4225Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,gain,inputVal)
 end
 
-function DAQmxSetup433xCal(calHandle::CalHandle,channelNames::Ptr{Uint8},excitationVoltage::float64)
-    ccall((:DAQmxSetup433xCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,excitationVoltage)
+function DAQmxSetup433xCal(calHandle::CalHandle,channelNames::Ptr{UInt8},excitationVoltage::float64)
+    ccall((:DAQmxSetup433xCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,excitationVoltage)
 end
 
 function DAQmxAdjust433xCal(calHandle::CalHandle,refVoltage::float64,refExcitation::float64,shuntLocation::int32)
     ccall((:DAQmxAdjust433xCal,NIDAQmx),int32,(CalHandle,float64,float64,int32),calHandle,refVoltage,refExcitation,shuntLocation)
 end
 
-function DAQmxSetup4339Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},calMode::int32,rangeMax::float64,rangeMin::float64,excitationVoltage::float64)
-    ccall((:DAQmxSetup4339Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32,float64,float64,float64),calHandle,channelNames,calMode,rangeMax,rangeMin,excitationVoltage)
+function DAQmxSetup4339Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},calMode::int32,rangeMax::float64,rangeMin::float64,excitationVoltage::float64)
+    ccall((:DAQmxSetup4339Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32,float64,float64,float64),calHandle,channelNames,calMode,rangeMax,rangeMin,excitationVoltage)
 end
 
 function DAQmxAdjust4339Cal(calHandle::CalHandle,refVoltage::float64)
@@ -946,36 +946,36 @@ function DAQmxAdjust4300Cal(calHandle::CalHandle,refVoltage::float64)
     ccall((:DAQmxAdjust4300Cal,NIDAQmx),int32,(CalHandle,float64),calHandle,refVoltage)
 end
 
-function DAQmxAdjust4353Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},refVal::float64)
-    ccall((:DAQmxAdjust4353Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,refVal)
+function DAQmxAdjust4353Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},refVal::float64)
+    ccall((:DAQmxAdjust4353Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,refVal)
 end
 
-function DAQmxAdjust4357Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},refVals::Ptr{float64},numRefVals::int32)
-    ccall((:DAQmxAdjust4357Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},int32),calHandle,channelNames,refVals,numRefVals)
+function DAQmxAdjust4357Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},refVals::Ptr{float64},numRefVals::int32)
+    ccall((:DAQmxAdjust4357Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},int32),calHandle,channelNames,refVals,numRefVals)
 end
 
-function DAQmxSetup4322Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},outputType::int32,outputVal::float64)
-    ccall((:DAQmxSetup4322Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32,float64),calHandle,channelNames,outputType,outputVal)
+function DAQmxSetup4322Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},outputType::int32,outputVal::float64)
+    ccall((:DAQmxSetup4322Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32,float64),calHandle,channelNames,outputType,outputVal)
 end
 
-function DAQmxAdjust4322Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},refVal::float64)
-    ccall((:DAQmxAdjust4322Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,refVal)
+function DAQmxAdjust4322Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},refVal::float64)
+    ccall((:DAQmxAdjust4322Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,refVal)
 end
 
 function DAQmxGet4322CalAdjustPoints(calHandle::CalHandle,outputType::int32,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet4322CalAdjustPoints,NIDAQmx),int32,(CalHandle,int32,Ptr{float64},uInt32),calHandle,outputType,adjustmentPoints,bufferSize)
 end
 
-function DAQmxConnectSCExpressCalAccChans(calHandle::CalHandle,channelNames::Ptr{Uint8},connection::Ptr{Uint8})
-    ccall((:DAQmxConnectSCExpressCalAccChans,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{Uint8}),calHandle,channelNames,connection)
+function DAQmxConnectSCExpressCalAccChans(calHandle::CalHandle,channelNames::Ptr{UInt8},connection::Ptr{UInt8})
+    ccall((:DAQmxConnectSCExpressCalAccChans,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{UInt8}),calHandle,channelNames,connection)
 end
 
 function DAQmxDisconnectSCExpressCalAccChans(calHandle::CalHandle)
     ccall((:DAQmxDisconnectSCExpressCalAccChans,NIDAQmx),int32,(CalHandle,),calHandle)
 end
 
-function DAQmxGetPossibleSCExpressCalAccConnections(deviceName::Ptr{Uint8},channelNames::Ptr{Uint8},connections::Ptr{Uint8},connectionsBufferSize::uInt32)
-    ccall((:DAQmxGetPossibleSCExpressCalAccConnections,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,channelNames,connections,connectionsBufferSize)
+function DAQmxGetPossibleSCExpressCalAccConnections(deviceName::Ptr{UInt8},channelNames::Ptr{UInt8},connections::Ptr{UInt8},connectionsBufferSize::uInt32)
+    ccall((:DAQmxGetPossibleSCExpressCalAccConnections,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,channelNames,connections,connectionsBufferSize)
 end
 
 function DAQmxSetSCExpressCalAccBridgeOutput(calHandle::CalHandle,voltsPerVolt::float64)
@@ -990,20 +990,20 @@ function DAQmxCSeriesSetCalTemp(calHandle::CalHandle,temperature::float64)
     ccall((:DAQmxCSeriesSetCalTemp,NIDAQmx),int32,(CalHandle,float64),calHandle,temperature)
 end
 
-function DAQmxAdjust9201Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9201Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9201Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9201Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9203CalAdjustPoints(calHandle::CalHandle,rangeMin::float64,rangeMax::float64,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9203CalAdjustPoints,NIDAQmx),int32,(CalHandle,float64,float64,Ptr{float64},uInt32),calHandle,rangeMin,rangeMax,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9203GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,value::float64)
-    ccall((:DAQmxAdjust9203GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
+function DAQmxAdjust9203GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,value::float64)
+    ccall((:DAQmxAdjust9203GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
 end
 
-function DAQmxAdjust9203OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64)
-    ccall((:DAQmxAdjust9203OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,rangeMin,rangeMax)
+function DAQmxAdjust9203OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64)
+    ccall((:DAQmxAdjust9203OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,rangeMin,rangeMax)
 end
 
 function DAQmxAdjust9205Cal(calHandle::CalHandle,value::float64)
@@ -1014,408 +1014,408 @@ function DAQmxAdjust9206Cal(calHandle::CalHandle,value::float64)
     ccall((:DAQmxAdjust9206Cal,NIDAQmx),int32,(CalHandle,float64),calHandle,value)
 end
 
-function DAQmxGet9207CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{Uint8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
-    ccall((:DAQmxGet9207CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
+function DAQmxGet9207CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{UInt8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
+    ccall((:DAQmxGet9207CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9207GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9207GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9207GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9207GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9207OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAdjust9207OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelNames)
+function DAQmxAdjust9207OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAdjust9207OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelNames)
 end
 
 function DAQmxGet9208CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9208CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9208GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9208GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9208GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9208GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9208OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAdjust9208OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelNames)
+function DAQmxAdjust9208OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAdjust9208OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelNames)
 end
 
-function DAQmxAdjust9211Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9211Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9211Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9211Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxGet9212CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{Uint8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
-    ccall((:DAQmxGet9212CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
+function DAQmxGet9212CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{UInt8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
+    ccall((:DAQmxGet9212CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9212Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9212Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9212Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9212Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9213CalAdjustPoints(calHandle::CalHandle,rangeMin::float64,rangeMax::float64,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9213CalAdjustPoints,NIDAQmx),int32,(CalHandle,float64,float64,Ptr{float64},uInt32),calHandle,rangeMin,rangeMax,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9213Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,value::float64)
-    ccall((:DAQmxAdjust9213Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
+function DAQmxAdjust9213Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,value::float64)
+    ccall((:DAQmxAdjust9213Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
 end
 
-function DAQmxGet9214CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{Uint8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
-    ccall((:DAQmxGet9214CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
+function DAQmxGet9214CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{UInt8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
+    ccall((:DAQmxGet9214CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9214Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9214Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9214Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9214Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9215CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9215CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9215Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9215Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9215Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9215Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9217CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9217CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9217Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9217Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9217Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9217Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxSetup9218Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,measType::int32)
-    ccall((:DAQmxSetup9218Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,int32),calHandle,channelNames,rangeMin,rangeMax,measType)
+function DAQmxSetup9218Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,measType::int32)
+    ccall((:DAQmxSetup9218Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,int32),calHandle,channelNames,rangeMin,rangeMax,measType)
 end
 
 function DAQmxGet9218CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9218CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9218Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9218Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9218Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9218Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxSetup9219Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,measType::int32,bridgeConfig::int32)
-    ccall((:DAQmxSetup9219Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,int32,int32),calHandle,channelNames,rangeMin,rangeMax,measType,bridgeConfig)
+function DAQmxSetup9219Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,measType::int32,bridgeConfig::int32)
+    ccall((:DAQmxSetup9219Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,int32,int32),calHandle,channelNames,rangeMin,rangeMax,measType,bridgeConfig)
 end
 
 function DAQmxGet9219CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9219CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9219Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9219Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9219Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9219Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9220CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9220CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9220Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9220Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9220Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9220Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9221CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9221CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9221Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9221Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9221Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9221Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9222CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9222CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9222Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9222Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9222Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9222Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9223CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9223CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9223Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9223Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9223Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9223Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9225CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9225CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9225Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9225Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9225Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9225Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9227CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9227CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9227Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9227Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9227Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9227Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9229CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9229CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9229Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9229Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9229Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9229Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9232CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9232CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9232Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9232Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9232Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9232Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9234CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9234CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9234GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9234GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9234GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9234GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9234OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAdjust9234OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelNames)
+function DAQmxAdjust9234OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAdjust9234OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelNames)
 end
 
 function DAQmxGet9238CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9238CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9238Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9238Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9238Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9238Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9239CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9239CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9239Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9239Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9239Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9239Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9242CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9242CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9242Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxSetup9242Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxSetup9242Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxSetup9242Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9242Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9242Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9242Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9242Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9244CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9244CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9244Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxSetup9244Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxSetup9244Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxSetup9244Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9244Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9244Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9244Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9244Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9263CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9263CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9263Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9263Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9263Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9263Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9263Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9263Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9263Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9263Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9264CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9264CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9264Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9264Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9264Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9264Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9264Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9264Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9264Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9264Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9265CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9265CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9265Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9265Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9265Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9265Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9265Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9265Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9265Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9265Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9269CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9269CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9269Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9269Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9269Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9269Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9269Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9269Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9269Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9269Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxSetup1102Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1102Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1102Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1102Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1102Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1102Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1104Cal(calHandle::CalHandle,channelName::Ptr{Uint8})
-    ccall((:DAQmxSetup1104Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelName)
+function DAQmxSetup1104Cal(calHandle::CalHandle,channelName::Ptr{UInt8})
+    ccall((:DAQmxSetup1104Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelName)
 end
 
 function DAQmxAdjust1104Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1104Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1112Cal(calHandle::CalHandle,channelName::Ptr{Uint8})
-    ccall((:DAQmxSetup1112Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelName)
+function DAQmxSetup1112Cal(calHandle::CalHandle,channelName::Ptr{UInt8})
+    ccall((:DAQmxSetup1112Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelName)
 end
 
 function DAQmxAdjust1112Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1112Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1122Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1122Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1122Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1122Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1122Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1122Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1124Cal(calHandle::CalHandle,channelName::Ptr{Uint8},range::int32,dacValue::uInt32)
-    ccall((:DAQmxSetup1124Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32,uInt32),calHandle,channelName,range,dacValue)
+function DAQmxSetup1124Cal(calHandle::CalHandle,channelName::Ptr{UInt8},range::int32,dacValue::uInt32)
+    ccall((:DAQmxSetup1124Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32,uInt32),calHandle,channelName,range,dacValue)
 end
 
 function DAQmxAdjust1124Cal(calHandle::CalHandle,measOutput::float64)
     ccall((:DAQmxAdjust1124Cal,NIDAQmx),int32,(CalHandle,float64),calHandle,measOutput)
 end
 
-function DAQmxSetup1125Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1125Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1125Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1125Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1125Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1125Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1126Cal(calHandle::CalHandle,channelName::Ptr{Uint8},upperFreqLimit::float64)
-    ccall((:DAQmxSetup1126Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,upperFreqLimit)
+function DAQmxSetup1126Cal(calHandle::CalHandle,channelName::Ptr{UInt8},upperFreqLimit::float64)
+    ccall((:DAQmxSetup1126Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,upperFreqLimit)
 end
 
 function DAQmxAdjust1126Cal(calHandle::CalHandle,refFreq::float64,measOutput::float64)
     ccall((:DAQmxAdjust1126Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refFreq,measOutput)
 end
 
-function DAQmxSetup1141Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1141Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1141Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1141Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1141Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1141Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1142Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1142Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1142Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1142Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1142Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1142Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1143Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1143Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1143Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1143Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1143Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1143Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1502Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1502Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1502Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1502Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1502Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1502Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1503Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1503Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1503Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1503Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1503Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1503Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxAdjust1503CurrentCal(calHandle::CalHandle,channelName::Ptr{Uint8},measCurrent::float64)
-    ccall((:DAQmxAdjust1503CurrentCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,measCurrent)
+function DAQmxAdjust1503CurrentCal(calHandle::CalHandle,channelName::Ptr{UInt8},measCurrent::float64)
+    ccall((:DAQmxAdjust1503CurrentCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,measCurrent)
 end
 
-function DAQmxSetup1520Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1520Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1520Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1520Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1520Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1520Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1521Cal(calHandle::CalHandle,channelName::Ptr{Uint8})
-    ccall((:DAQmxSetup1521Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelName)
+function DAQmxSetup1521Cal(calHandle::CalHandle,channelName::Ptr{UInt8})
+    ccall((:DAQmxSetup1521Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelName)
 end
 
 function DAQmxAdjust1521Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1521Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup153xCal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup153xCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup153xCal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup153xCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust153xCal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust153xCal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1540Cal(calHandle::CalHandle,channelName::Ptr{Uint8},excitationVoltage::float64,excitationFreq::float64)
-    ccall((:DAQmxSetup1540Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelName,excitationVoltage,excitationFreq)
+function DAQmxSetup1540Cal(calHandle::CalHandle,channelName::Ptr{UInt8},excitationVoltage::float64,excitationFreq::float64)
+    ccall((:DAQmxSetup1540Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelName,excitationVoltage,excitationFreq)
 end
 
 function DAQmxAdjust1540Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64,inputCalSource::int32)
     ccall((:DAQmxAdjust1540Cal,NIDAQmx),int32,(CalHandle,float64,float64,int32),calHandle,refVoltage,measOutput,inputCalSource)
 end
 
-function DAQmxConfigureTEDS(physicalChannel::Ptr{Uint8},filePath::Ptr{Uint8})
-    ccall((:DAQmxConfigureTEDS,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),physicalChannel,filePath)
+function DAQmxConfigureTEDS(physicalChannel::Ptr{UInt8},filePath::Ptr{UInt8})
+    ccall((:DAQmxConfigureTEDS,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),physicalChannel,filePath)
 end
 
-function DAQmxClearTEDS(physicalChannel::Ptr{Uint8})
-    ccall((:DAQmxClearTEDS,NIDAQmx),int32,(Ptr{Uint8},),physicalChannel)
+function DAQmxClearTEDS(physicalChannel::Ptr{UInt8})
+    ccall((:DAQmxClearTEDS,NIDAQmx),int32,(Ptr{UInt8},),physicalChannel)
 end
 
-function DAQmxWriteToTEDSFromArray(physicalChannel::Ptr{Uint8},bitStream::Ptr{uInt8},arraySize::uInt32,basicTEDSOptions::int32)
-    ccall((:DAQmxWriteToTEDSFromArray,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt8},uInt32,int32),physicalChannel,bitStream,arraySize,basicTEDSOptions)
+function DAQmxWriteToTEDSFromArray(physicalChannel::Ptr{UInt8},bitStream::Ptr{uInt8},arraySize::uInt32,basicTEDSOptions::int32)
+    ccall((:DAQmxWriteToTEDSFromArray,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt8},uInt32,int32),physicalChannel,bitStream,arraySize,basicTEDSOptions)
 end
 
-function DAQmxWriteToTEDSFromFile(physicalChannel::Ptr{Uint8},filePath::Ptr{Uint8},basicTEDSOptions::int32)
-    ccall((:DAQmxWriteToTEDSFromFile,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},int32),physicalChannel,filePath,basicTEDSOptions)
+function DAQmxWriteToTEDSFromFile(physicalChannel::Ptr{UInt8},filePath::Ptr{UInt8},basicTEDSOptions::int32)
+    ccall((:DAQmxWriteToTEDSFromFile,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},int32),physicalChannel,filePath,basicTEDSOptions)
 end
 
 function DAQmxWaitForNextSampleClock(taskHandle::TaskHandle,timeout::float64,isLate::Ptr{bool32})
@@ -1430,92 +1430,92 @@ function DAQmxIsReadOrWriteLate(errorCode::int32)
     ccall((:DAQmxIsReadOrWriteLate,NIDAQmx),bool32,(int32,),errorCode)
 end
 
-function DAQmxSaveTask(taskHandle::TaskHandle,saveAs::Ptr{Uint8},author::Ptr{Uint8},options::uInt32)
-    ccall((:DAQmxSaveTask,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,saveAs,author,options)
+function DAQmxSaveTask(taskHandle::TaskHandle,saveAs::Ptr{UInt8},author::Ptr{UInt8},options::uInt32)
+    ccall((:DAQmxSaveTask,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,saveAs,author,options)
 end
 
-function DAQmxSaveGlobalChan(taskHandle::TaskHandle,channelName::Ptr{Uint8},saveAs::Ptr{Uint8},author::Ptr{Uint8},options::uInt32)
-    ccall((:DAQmxSaveGlobalChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channelName,saveAs,author,options)
+function DAQmxSaveGlobalChan(taskHandle::TaskHandle,channelName::Ptr{UInt8},saveAs::Ptr{UInt8},author::Ptr{UInt8},options::uInt32)
+    ccall((:DAQmxSaveGlobalChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channelName,saveAs,author,options)
 end
 
-function DAQmxSaveScale(scaleName::Ptr{Uint8},saveAs::Ptr{Uint8},author::Ptr{Uint8},options::uInt32)
-    ccall((:DAQmxSaveScale,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,saveAs,author,options)
+function DAQmxSaveScale(scaleName::Ptr{UInt8},saveAs::Ptr{UInt8},author::Ptr{UInt8},options::uInt32)
+    ccall((:DAQmxSaveScale,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,saveAs,author,options)
 end
 
-function DAQmxDeleteSavedTask(taskName::Ptr{Uint8})
-    ccall((:DAQmxDeleteSavedTask,NIDAQmx),int32,(Ptr{Uint8},),taskName)
+function DAQmxDeleteSavedTask(taskName::Ptr{UInt8})
+    ccall((:DAQmxDeleteSavedTask,NIDAQmx),int32,(Ptr{UInt8},),taskName)
 end
 
-function DAQmxDeleteSavedGlobalChan(channelName::Ptr{Uint8})
-    ccall((:DAQmxDeleteSavedGlobalChan,NIDAQmx),int32,(Ptr{Uint8},),channelName)
+function DAQmxDeleteSavedGlobalChan(channelName::Ptr{UInt8})
+    ccall((:DAQmxDeleteSavedGlobalChan,NIDAQmx),int32,(Ptr{UInt8},),channelName)
 end
 
-function DAQmxDeleteSavedScale(scaleName::Ptr{Uint8})
-    ccall((:DAQmxDeleteSavedScale,NIDAQmx),int32,(Ptr{Uint8},),scaleName)
+function DAQmxDeleteSavedScale(scaleName::Ptr{UInt8})
+    ccall((:DAQmxDeleteSavedScale,NIDAQmx),int32,(Ptr{UInt8},),scaleName)
 end
 
-function DAQmxSetAnalogPowerUpStatesWithOutputType(channelNames::Ptr{Uint8},stateArray::Ptr{float64},channelTypeArray::Ptr{int32},arraySize::uInt32)
-    ccall((:DAQmxSetAnalogPowerUpStatesWithOutputType,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},Ptr{int32},uInt32),channelNames,stateArray,channelTypeArray,arraySize)
+function DAQmxSetAnalogPowerUpStatesWithOutputType(channelNames::Ptr{UInt8},stateArray::Ptr{float64},channelTypeArray::Ptr{int32},arraySize::uInt32)
+    ccall((:DAQmxSetAnalogPowerUpStatesWithOutputType,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},Ptr{int32},uInt32),channelNames,stateArray,channelTypeArray,arraySize)
 end
 
-function DAQmxGetAnalogPowerUpStatesWithOutputType(channelNames::Ptr{Uint8},stateArray::Ptr{float64},channelTypeArray::Ptr{int32},arraySizePtr::Ptr{uInt32})
-    ccall((:DAQmxGetAnalogPowerUpStatesWithOutputType,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},Ptr{int32},Ptr{uInt32}),channelNames,stateArray,channelTypeArray,arraySizePtr)
+function DAQmxGetAnalogPowerUpStatesWithOutputType(channelNames::Ptr{UInt8},stateArray::Ptr{float64},channelTypeArray::Ptr{int32},arraySizePtr::Ptr{uInt32})
+    ccall((:DAQmxGetAnalogPowerUpStatesWithOutputType,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},Ptr{int32},Ptr{uInt32}),channelNames,stateArray,channelTypeArray,arraySizePtr)
 end
 
-function DAQmxSetDigitalLogicFamilyPowerUpState(deviceName::Ptr{Uint8},logicFamily::int32)
-    ccall((:DAQmxSetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{Uint8},int32),deviceName,logicFamily)
+function DAQmxSetDigitalLogicFamilyPowerUpState(deviceName::Ptr{UInt8},logicFamily::int32)
+    ccall((:DAQmxSetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{UInt8},int32),deviceName,logicFamily)
 end
 
-function DAQmxGetDigitalLogicFamilyPowerUpState(deviceName::Ptr{Uint8},logicFamily::Ptr{int32})
-    ccall((:DAQmxGetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),deviceName,logicFamily)
+function DAQmxGetDigitalLogicFamilyPowerUpState(deviceName::Ptr{UInt8},logicFamily::Ptr{int32})
+    ccall((:DAQmxGetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),deviceName,logicFamily)
 end
 
-function DAQmxAddNetworkDevice(IPAddress::Ptr{Uint8},deviceName::Ptr{Uint8},attemptReservation::bool32,timeout::float64,deviceNameOut::Ptr{Uint8},deviceNameOutBufferSize::uInt32)
-    ccall((:DAQmxAddNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},bool32,float64,Ptr{Uint8},uInt32),IPAddress,deviceName,attemptReservation,timeout,deviceNameOut,deviceNameOutBufferSize)
+function DAQmxAddNetworkDevice(IPAddress::Ptr{UInt8},deviceName::Ptr{UInt8},attemptReservation::bool32,timeout::float64,deviceNameOut::Ptr{UInt8},deviceNameOutBufferSize::uInt32)
+    ccall((:DAQmxAddNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},bool32,float64,Ptr{UInt8},uInt32),IPAddress,deviceName,attemptReservation,timeout,deviceNameOut,deviceNameOutBufferSize)
 end
 
-function DAQmxDeleteNetworkDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxDeleteNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxDeleteNetworkDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxDeleteNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxReserveNetworkDevice(deviceName::Ptr{Uint8},overrideReservation::bool32)
-    ccall((:DAQmxReserveNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,overrideReservation)
+function DAQmxReserveNetworkDevice(deviceName::Ptr{UInt8},overrideReservation::bool32)
+    ccall((:DAQmxReserveNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,overrideReservation)
 end
 
-function DAQmxUnreserveNetworkDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxUnreserveNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxUnreserveNetworkDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxUnreserveNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxAutoConfigureCDAQSyncConnections(chassisDevicesPorts::Ptr{Uint8},timeout::float64)
-    ccall((:DAQmxAutoConfigureCDAQSyncConnections,NIDAQmx),int32,(Ptr{Uint8},float64),chassisDevicesPorts,timeout)
+function DAQmxAutoConfigureCDAQSyncConnections(chassisDevicesPorts::Ptr{UInt8},timeout::float64)
+    ccall((:DAQmxAutoConfigureCDAQSyncConnections,NIDAQmx),int32,(Ptr{UInt8},float64),chassisDevicesPorts,timeout)
 end
 
-function DAQmxGetAutoConfiguredCDAQSyncConnections(portList::Ptr{Uint8},portListSize::uInt32)
-    ccall((:DAQmxGetAutoConfiguredCDAQSyncConnections,NIDAQmx),int32,(Ptr{Uint8},uInt32),portList,portListSize)
+function DAQmxGetAutoConfiguredCDAQSyncConnections(portList::Ptr{UInt8},portListSize::uInt32)
+    ccall((:DAQmxGetAutoConfiguredCDAQSyncConnections,NIDAQmx),int32,(Ptr{UInt8},uInt32),portList,portListSize)
 end
 
-function DAQmxAreConfiguredCDAQSyncPortsDisconnected(chassisDevicesPorts::Ptr{Uint8},timeout::float64,disconnectedPortsExist::Ptr{bool32})
-    ccall((:DAQmxAreConfiguredCDAQSyncPortsDisconnected,NIDAQmx),int32,(Ptr{Uint8},float64,Ptr{bool32}),chassisDevicesPorts,timeout,disconnectedPortsExist)
+function DAQmxAreConfiguredCDAQSyncPortsDisconnected(chassisDevicesPorts::Ptr{UInt8},timeout::float64,disconnectedPortsExist::Ptr{bool32})
+    ccall((:DAQmxAreConfiguredCDAQSyncPortsDisconnected,NIDAQmx),int32,(Ptr{UInt8},float64,Ptr{bool32}),chassisDevicesPorts,timeout,disconnectedPortsExist)
 end
 
-function DAQmxGetDisconnectedCDAQSyncPorts(portList::Ptr{Uint8},portListSize::uInt32)
-    ccall((:DAQmxGetDisconnectedCDAQSyncPorts,NIDAQmx),int32,(Ptr{Uint8},uInt32),portList,portListSize)
+function DAQmxGetDisconnectedCDAQSyncPorts(portList::Ptr{UInt8},portListSize::uInt32)
+    ccall((:DAQmxGetDisconnectedCDAQSyncPorts,NIDAQmx),int32,(Ptr{UInt8},uInt32),portList,portListSize)
 end
 
-function DAQmxAddCDAQSyncConnection(portList::Ptr{Uint8})
-    ccall((:DAQmxAddCDAQSyncConnection,NIDAQmx),int32,(Ptr{Uint8},),portList)
+function DAQmxAddCDAQSyncConnection(portList::Ptr{UInt8})
+    ccall((:DAQmxAddCDAQSyncConnection,NIDAQmx),int32,(Ptr{UInt8},),portList)
 end
 
-function DAQmxRemoveCDAQSyncConnection(portList::Ptr{Uint8})
-    ccall((:DAQmxRemoveCDAQSyncConnection,NIDAQmx),int32,(Ptr{Uint8},),portList)
+function DAQmxRemoveCDAQSyncConnection(portList::Ptr{UInt8})
+    ccall((:DAQmxRemoveCDAQSyncConnection,NIDAQmx),int32,(Ptr{UInt8},),portList)
 end
 
-function DAQmxGetErrorString(errorCode::int32,errorString::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetErrorString,NIDAQmx),int32,(int32,Ptr{Uint8},uInt32),errorCode,errorString,bufferSize)
+function DAQmxGetErrorString(errorCode::int32,errorString::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetErrorString,NIDAQmx),int32,(int32,Ptr{UInt8},uInt32),errorCode,errorString,bufferSize)
 end
 
-function DAQmxGetExtendedErrorInfo(errorString::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExtendedErrorInfo,NIDAQmx),int32,(Ptr{Uint8},uInt32),errorString,bufferSize)
+function DAQmxGetExtendedErrorInfo(errorString::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExtendedErrorInfo,NIDAQmx),int32,(Ptr{UInt8},uInt32),errorString,bufferSize)
 end
 
 function DAQmxGetBufInputBufSize(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -1558,5000 +1558,5000 @@ function DAQmxResetBufOutputOnbrdBufSize(taskHandle::TaskHandle)
     ccall((:DAQmxResetBufOutputOnbrdBufSize,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSelfCalSupported(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSelfCalSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSelfCalSupported(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSelfCalSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxGetSelfCalLastTemp(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSelfCalLastTemp,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetSelfCalLastTemp(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSelfCalLastTemp,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxGetExtCalRecommendedInterval(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetExtCalRecommendedInterval,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetExtCalRecommendedInterval(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetExtCalRecommendedInterval,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetExtCalLastTemp(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetExtCalLastTemp,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetExtCalLastTemp(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetExtCalLastTemp,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxGetCalUserDefinedInfo(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetCalUserDefinedInfo(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxSetCalUserDefinedInfo(deviceName::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),deviceName,data)
+function DAQmxSetCalUserDefinedInfo(deviceName::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),deviceName,data)
 end
 
-function DAQmxGetCalUserDefinedInfoMaxSize(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCalUserDefinedInfoMaxSize,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetCalUserDefinedInfoMaxSize(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCalUserDefinedInfoMaxSize,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetCalDevTemp(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCalDevTemp,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetCalDevTemp(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCalDevTemp,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxGetCalAccConnectionCount(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCalAccConnectionCount,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetCalAccConnectionCount(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCalAccConnectionCount,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxSetCalAccConnectionCount(deviceName::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCalAccConnectionCount,NIDAQmx),int32,(Ptr{Uint8},uInt32),deviceName,data)
+function DAQmxSetCalAccConnectionCount(deviceName::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCalAccConnectionCount,NIDAQmx),int32,(Ptr{UInt8},uInt32),deviceName,data)
 end
 
-function DAQmxGetCalRecommendedAccConnectionCountLimit(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCalRecommendedAccConnectionCountLimit,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetCalRecommendedAccConnectionCountLimit(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCalRecommendedAccConnectionCountLimit,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetAIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMax(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMax(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMin(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMin(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAITempUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAITempUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAITempUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAITempUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAITempUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAITempUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplCJCSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIThrmcplCJCSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplCJCSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIThrmcplCJCSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplCJCChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIThrmcplCJCChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIThrmcplCJCChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIThrmcplCJCChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxGetAIRTDType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRTDType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRTDType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDA(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDA(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDB(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDB(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDC(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDC(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRosetteStrainGageRosetteType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRosetteStrainGageRosetteType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRosetteStrainGageRosetteType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRosetteStrainGageRosetteType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRosetteStrainGageStrainChans(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIRosetteStrainGageStrainChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIRosetteStrainGageStrainChans(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIRosetteStrainGageStrainChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxGetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIIsTEDS(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIIsTEDS,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIIsTEDS(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIIsTEDS,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAITEDSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAITEDSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAITEDSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAITEDSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxGetAICoupling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICoupling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICoupling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICoupling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICoupling(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICoupling(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAITermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAITermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAITermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAITermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAITermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAITermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAtten(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAtten(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIResolution(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIResolution,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIResolution(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIResolution,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRawSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIRawSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIRawSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIRawSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRawSampJustification(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRawSampJustification,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRawSampJustification(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRawSampJustification,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalHasValidCalInfo(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIChanCalHasValidCalInfo,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalHasValidCalInfo(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIChanCalHasValidCalInfo,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIGain(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIGain(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIDevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIDevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIDevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxGetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOMax(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOMax(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOMin(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOMin(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOOutputType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOOutputType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOResolution(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOResolution,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOResolution(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOResolution,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxGetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFilterDelayUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFilterDelayUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFilterDelayAdjustment(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFilterDelayAdjustment,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOGain(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOGain(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAODevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAODevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAODevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxGetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDINumLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDINumLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDINumLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDINumLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDITristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDITristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDITristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDITristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDITristate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDITristate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDONumLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDONumLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDONumLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDONumLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetDOTristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOTristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOTristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOTristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOTristate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOTristate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIMax(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIMax(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIMin(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIMin(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCIOutputState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIOutputState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIOutputState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIOutputState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCITCReached(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITCReached,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITCReached(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITCReached,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCINumPossiblyInvalidSamps(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCINumPossiblyInvalidSamps,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCINumPossiblyInvalidSamps(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCINumPossiblyInvalidSamps,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOOutputType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOOutputType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOOutputState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOOutputState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOOutputState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOOutputState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseDone(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOPulseDone,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOPulseDone(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOPulseDone,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCORdyForNewVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCORdyForNewVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCORdyForNewVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCORdyForNewVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetChanType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetChanType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetChanType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetChanType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxGetChanDescr(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetChanDescr(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetChanDescr(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetChanDescr(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetChanDescr(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetChanDescr(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetChanIsGlobal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetChanIsGlobal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetChanIsGlobal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetChanIsGlobal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAIConvClkOutputTerm(taskHandle::TaskHandle)
@@ -6562,24 +6562,24 @@ function DAQmxGetExportedAIConvClkPulsePolarity(taskHandle::TaskHandle,data::Ptr
     ccall((:DAQmxGetExportedAIConvClkPulsePolarity,NIDAQmx),int32,(TaskHandle,Ptr{int32}),taskHandle,data)
 end
 
-function DAQmxGetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle)
@@ -6598,12 +6598,12 @@ function DAQmxResetExportedSampClkOutputBehavior(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSampClkOutputBehavior,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedSampClkOutputTerm(taskHandle::TaskHandle)
@@ -6634,36 +6634,36 @@ function DAQmxResetExportedSampClkPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSampClkPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAdvTrigOutputTerm(taskHandle::TaskHandle)
@@ -6698,12 +6698,12 @@ function DAQmxResetExportedAdvTrigPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedAdvTrigPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedPauseTrigOutputTerm(taskHandle::TaskHandle)
@@ -6722,12 +6722,12 @@ function DAQmxResetExportedPauseTrigLvlActiveLvl(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedPauseTrigLvlActiveLvl,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedRefTrigOutputTerm(taskHandle::TaskHandle)
@@ -6746,12 +6746,12 @@ function DAQmxResetExportedRefTrigPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedRefTrigPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedStartTrigOutputTerm(taskHandle::TaskHandle)
@@ -6770,12 +6770,12 @@ function DAQmxResetExportedStartTrigPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedStartTrigPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle)
@@ -6818,12 +6818,12 @@ function DAQmxResetExportedAdvCmpltEventPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedAdvCmpltEventPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle)
@@ -6842,12 +6842,12 @@ function DAQmxResetExportedAIHoldCmpltEventPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedAIHoldCmpltEventPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle)
@@ -6866,12 +6866,12 @@ function DAQmxResetExportedChangeDetectEventPulsePolarity(taskHandle::TaskHandle
     ccall((:DAQmxResetExportedChangeDetectEventPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle)
@@ -6914,12 +6914,12 @@ function DAQmxResetExportedCtrOutEventToggleIdleState(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedCtrOutEventToggleIdleState,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedHshkEventOutputTerm(taskHandle::TaskHandle)
@@ -7010,12 +7010,12 @@ function DAQmxResetExportedHshkEventPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedHshkEventPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle)
@@ -7058,12 +7058,12 @@ function DAQmxResetExportedRdyForXferEventDeassertCondCustomThreshold(taskHandle
     ccall((:DAQmxResetExportedRdyForXferEventDeassertCondCustomThreshold,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle)
@@ -7082,12 +7082,12 @@ function DAQmxResetExportedDataActiveEventLvlActiveLvl(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedDataActiveEventLvlActiveLvl,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle)
@@ -7106,336 +7106,336 @@ function DAQmxResetExportedRdyForStartEventLvlActiveLvl(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedRdyForStartEventLvlActiveLvl,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDevIsSimulated(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevIsSimulated,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevIsSimulated(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevIsSimulated,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevProductCategory(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevProductCategory,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevProductCategory(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevProductCategory,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevProductType(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevProductType,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevProductType(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevProductType,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevProductNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevProductNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevProductNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevProductNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevSerialNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevSerialNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevSerialNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevSerialNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevAccessoryProductTypes(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevAccessoryProductTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevAccessoryProductTypes(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevAccessoryProductTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAccessoryProductNums(device::Ptr{Uint8},data::Ptr{uInt32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAccessoryProductNums,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAccessoryProductNums(device::Ptr{UInt8},data::Ptr{uInt32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAccessoryProductNums,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAccessorySerialNums(device::Ptr{Uint8},data::Ptr{uInt32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAccessorySerialNums,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAccessorySerialNums(device::Ptr{UInt8},data::Ptr{uInt32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAccessorySerialNums,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetCarrierSerialNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCarrierSerialNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetCarrierSerialNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCarrierSerialNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevChassisModuleDevNames(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevChassisModuleDevNames,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevChassisModuleDevNames(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevChassisModuleDevNames,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAnlgTrigSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevAnlgTrigSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevAnlgTrigSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevAnlgTrigSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevDigTrigSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevDigTrigSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevDigTrigSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevDigTrigSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevAIPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevAIPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevAIPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevAIPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAISupportedMeasTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAISupportedMeasTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIMaxSingleChanRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAIMaxSingleChanRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAIMaxSingleChanRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAIMaxSingleChanRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAIMaxMultiChanRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAIMaxMultiChanRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAIMaxMultiChanRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAIMaxMultiChanRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAIMinRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAIMinRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAIMinRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAIMinRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAISimultaneousSamplingSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevAISimultaneousSamplingSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevAISimultaneousSamplingSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevAISimultaneousSamplingSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevAISampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAISampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAISampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAISampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAITrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevAITrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevAITrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevAITrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevAIVoltageRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIVoltageRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIVoltageRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIVoltageRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIVoltageIntExcitDiscreteVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIVoltageIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIVoltageIntExcitDiscreteVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIVoltageIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIVoltageIntExcitRangeVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIVoltageIntExcitRangeVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIVoltageIntExcitRangeVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIVoltageIntExcitRangeVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAICurrentRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAICurrentRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAICurrentRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAICurrentRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAICurrentIntExcitDiscreteVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAICurrentIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAICurrentIntExcitDiscreteVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAICurrentIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIBridgeRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIBridgeRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIBridgeRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIBridgeRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIResistanceRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIResistanceRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIResistanceRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIResistanceRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIFreqRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIFreqRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIFreqRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIFreqRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIGains(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIGains,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIGains(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIGains,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAICouplings(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevAICouplings,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevAICouplings(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevAICouplings,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevAILowpassCutoffFreqDiscreteVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAILowpassCutoffFreqDiscreteVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAILowpassCutoffFreqDiscreteVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAILowpassCutoffFreqDiscreteVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAILowpassCutoffFreqRangeVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAILowpassCutoffFreqRangeVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAILowpassCutoffFreqRangeVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAILowpassCutoffFreqRangeVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevAOPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevAOPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevAOPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAOSupportedOutputTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOSupportedOutputTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOSampClkSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevAOSampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevAOSampClkSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevAOSampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevAOSampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOSampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOSampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOSampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOMaxRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAOMaxRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAOMaxRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAOMaxRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAOMinRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAOMinRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAOMinRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAOMinRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAOTrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevAOTrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevAOTrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevAOTrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevAOVoltageRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOVoltageRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOVoltageRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOVoltageRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOCurrentRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOCurrentRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOCurrentRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOCurrentRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOGains(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOGains,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOGains(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOGains,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevDILines(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDILines,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDILines(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDILines,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDIPorts(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDIPorts,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDIPorts(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDIPorts,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDIMaxRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevDIMaxRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevDIMaxRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevDIMaxRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevDITrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevDITrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevDITrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevDITrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevDOLines(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDOLines,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDOLines(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDOLines,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDOPorts(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDOPorts,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDOPorts(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDOPorts,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDOMaxRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevDOMaxRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevDOMaxRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevDOMaxRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevDOTrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevDOTrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevDOTrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevDOTrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevCIPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevCIPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevCIPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevCIPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevCISupportedMeasTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCISupportedMeasTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCITrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevCITrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevCITrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevCITrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevCISampClkSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevCISampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevCISampClkSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevCISampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevCISampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCISampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCISampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCISampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCIMaxSize(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevCIMaxSize,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevCIMaxSize(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevCIMaxSize,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevCIMaxTimebase(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevCIMaxTimebase,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevCIMaxTimebase(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevCIMaxTimebase,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevCOPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevCOPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevCOPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevCOPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevCOSupportedOutputTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCOSupportedOutputTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCOSampClkSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevCOSampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevCOSampClkSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevCOSampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevCOSampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCOSampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCOSampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCOSampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCOTrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevCOTrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevCOTrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevCOTrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevCOMaxSize(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevCOMaxSize,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevCOMaxSize(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevCOMaxSize,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevCOMaxTimebase(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevCOMaxTimebase,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevCOMaxTimebase(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevCOMaxTimebase,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevTEDSHWTEDSSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevTEDSHWTEDSSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevTEDSHWTEDSSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevTEDSHWTEDSSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevNumDMAChans(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevNumDMAChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevNumDMAChans(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevNumDMAChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevBusType(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevBusType,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevBusType(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevBusType,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevPCIBusNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPCIBusNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPCIBusNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPCIBusNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevPCIDevNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPCIDevNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPCIDevNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPCIDevNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevPXIChassisNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPXIChassisNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPXIChassisNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPXIChassisNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevPXISlotNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPXISlotNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPXISlotNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPXISlotNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevCompactDAQChassisDevName(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevCompactDAQChassisDevName,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevCompactDAQChassisDevName(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevCompactDAQChassisDevName,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevCompactDAQSlotNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevCompactDAQSlotNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevCompactDAQSlotNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevCompactDAQSlotNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevTCPIPHostname(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTCPIPHostname,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTCPIPHostname(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTCPIPHostname,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevTCPIPEthernetIP(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTCPIPEthernetIP,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTCPIPEthernetIP(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTCPIPEthernetIP,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevTCPIPWirelessIP(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTCPIPWirelessIP,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTCPIPWirelessIP(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTCPIPWirelessIP,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevTerminals(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTerminals,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTerminals(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTerminals,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
 function DAQmxGetReadRelativeTo(taskHandle::TaskHandle,data::Ptr{int32})
@@ -7462,12 +7462,12 @@ function DAQmxResetReadOffset(taskHandle::TaskHandle)
     ccall((:DAQmxResetReadOffset,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetReadChannelsToRead(taskHandle::TaskHandle)
@@ -7510,12 +7510,12 @@ function DAQmxResetReadOverWrite(taskHandle::TaskHandle)
     ccall((:DAQmxResetReadOverWrite,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetLoggingFilePath(taskHandle::TaskHandle)
@@ -7534,12 +7534,12 @@ function DAQmxResetLoggingMode(taskHandle::TaskHandle)
     ccall((:DAQmxResetLoggingMode,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetLoggingTDMSGroupName(taskHandle::TaskHandle)
@@ -7622,64 +7622,64 @@ function DAQmxGetReadCommonModeRangeErrorChansExist(taskHandle::TaskHandle,data:
     ccall((:DAQmxGetReadCommonModeRangeErrorChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadCommonModeRangeErrorChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadCommonModeRangeErrorChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadCommonModeRangeErrorChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadCommonModeRangeErrorChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadExcitFaultChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadExcitFaultChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadExcitFaultChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadExcitFaultChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadExcitFaultChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadExcitFaultChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOvercurrentChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOvercurrentChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOvercurrentChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOvercurrentChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOvertemperatureChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOvertemperatureChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOvertemperatureChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOvertemperatureChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOvertemperatureChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOvertemperatureChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOpenCurrentLoopChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOpenCurrentLoopChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOpenThrmcplChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOpenThrmcplChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOpenThrmcplChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOpenThrmcplChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOpenThrmcplChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOpenThrmcplChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOverloadedChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOverloadedChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOverloadedChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOverloadedChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadAccessoryInsertionOrRemovalDetected(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadAccessoryInsertionOrRemovalDetected,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadChangeDetectHasOverflowed(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -7782,132 +7782,132 @@ function DAQmxResetRealTimeWriteRecoveryMode(taskHandle::TaskHandle)
     ccall((:DAQmxResetRealTimeWriteRecoveryMode,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSwitchChanUsage(switchChannelName::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetSwitchChanUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),switchChannelName,data)
+function DAQmxGetSwitchChanUsage(switchChannelName::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetSwitchChanUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),switchChannelName,data)
 end
 
-function DAQmxSetSwitchChanUsage(switchChannelName::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetSwitchChanUsage,NIDAQmx),int32,(Ptr{Uint8},int32),switchChannelName,data)
+function DAQmxSetSwitchChanUsage(switchChannelName::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetSwitchChanUsage,NIDAQmx),int32,(Ptr{UInt8},int32),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),switchChannelName,data)
+function DAQmxGetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),switchChannelName,data)
 end
 
-function DAQmxSetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{Uint8},bool32),switchChannelName,data)
+function DAQmxSetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{UInt8},bool32),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACCarryCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACCarryCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACCarryCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACCarryCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACSwitchCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACSwitchCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACSwitchCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACSwitchCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACCarryPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACCarryPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACCarryPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACCarryPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACSwitchPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACSwitchPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACSwitchPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACSwitchPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCCarryCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCCarryCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCCarryCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCCarryCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCSwitchCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCSwitchCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCSwitchCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCSwitchCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCCarryPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCCarryPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCCarryPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCCarryPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCSwitchPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCSwitchPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCSwitchPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCSwitchPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACVoltage(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACVoltage,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACVoltage(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACVoltage,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCVoltage(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCVoltage,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCVoltage(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCVoltage,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanWireMode(switchChannelName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchChanWireMode,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),switchChannelName,data)
+function DAQmxGetSwitchChanWireMode(switchChannelName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchChanWireMode,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanBandwidth(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanBandwidth,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanBandwidth(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanBandwidth,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanImpedance(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanImpedance,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanImpedance(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanImpedance,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchDevSettlingTime(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetSwitchDevSettlingTime(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxSetSwitchDevSettlingTime(deviceName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{Uint8},float64),deviceName,data)
+function DAQmxSetSwitchDevSettlingTime(deviceName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{UInt8},float64),deviceName,data)
 end
 
-function DAQmxGetSwitchDevAutoConnAnlgBus(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSwitchDevAutoConnAnlgBus(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxSetSwitchDevAutoConnAnlgBus(deviceName::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,data)
+function DAQmxSetSwitchDevAutoConnAnlgBus(deviceName::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,data)
 end
 
-function DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,data)
+function DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,data)
 end
 
-function DAQmxGetSwitchDevSettled(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchDevSettled,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSwitchDevSettled(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchDevSettled,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevRelayList(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSwitchDevRelayList,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetSwitchDevRelayList(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSwitchDevRelayList,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxGetSwitchDevNumRelays(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumRelays,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumRelays(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumRelays,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevSwitchChanList(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSwitchDevSwitchChanList,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetSwitchDevSwitchChanList(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSwitchDevSwitchChanList,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxGetSwitchDevNumSwitchChans(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumSwitchChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumSwitchChans(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumSwitchChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevNumRows(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumRows,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumRows(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumRows,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevNumColumns(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumColumns,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumColumns(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumColumns,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevTopology(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSwitchDevTopology,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetSwitchDevTopology(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSwitchDevTopology,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxGetSwitchDevTemperature(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchDevTemperature,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetSwitchDevTemperature(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchDevTemperature,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
 function DAQmxGetSwitchScanBreakMode(taskHandle::TaskHandle,data::Ptr{int32})
@@ -7938,128 +7938,128 @@ function DAQmxGetSwitchScanWaitingForAdv(taskHandle::TaskHandle,data::Ptr{bool32
     ccall((:DAQmxGetSwitchScanWaitingForAdv,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetScaleDescr(scaleName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetScaleDescr,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,data,bufferSize)
+function DAQmxGetScaleDescr(scaleName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetScaleDescr,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,data,bufferSize)
 end
 
-function DAQmxSetScaleDescr(scaleName::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetScaleDescr,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),scaleName,data)
+function DAQmxSetScaleDescr(scaleName::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetScaleDescr,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),scaleName,data)
 end
 
-function DAQmxGetScaleScaledUnits(scaleName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetScaleScaledUnits,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,data,bufferSize)
+function DAQmxGetScaleScaledUnits(scaleName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetScaleScaledUnits,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,data,bufferSize)
 end
 
-function DAQmxSetScaleScaledUnits(scaleName::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetScaleScaledUnits,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),scaleName,data)
+function DAQmxSetScaleScaledUnits(scaleName::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetScaleScaledUnits,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),scaleName,data)
 end
 
-function DAQmxGetScalePreScaledUnits(scaleName::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetScalePreScaledUnits,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),scaleName,data)
+function DAQmxGetScalePreScaledUnits(scaleName::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetScalePreScaledUnits,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),scaleName,data)
 end
 
-function DAQmxSetScalePreScaledUnits(scaleName::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetScalePreScaledUnits,NIDAQmx),int32,(Ptr{Uint8},int32),scaleName,data)
+function DAQmxSetScalePreScaledUnits(scaleName::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetScalePreScaledUnits,NIDAQmx),int32,(Ptr{UInt8},int32),scaleName,data)
 end
 
-function DAQmxGetScaleType(scaleName::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetScaleType,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),scaleName,data)
+function DAQmxGetScaleType(scaleName::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetScaleType,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),scaleName,data)
 end
 
-function DAQmxGetScaleLinSlope(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleLinSlope,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleLinSlope(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleLinSlope,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleLinSlope(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleLinSlope,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleLinSlope(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleLinSlope,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleLinYIntercept(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleLinYIntercept,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleLinYIntercept(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleLinYIntercept,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleLinYIntercept(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleLinYIntercept,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleLinYIntercept(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleLinYIntercept,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapScaledMax(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapScaledMax,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapScaledMax(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapScaledMax,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapScaledMax(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapScaledMax,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapScaledMax(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapScaledMax,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapPreScaledMax(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapPreScaledMax(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapPreScaledMax(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapPreScaledMax(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapScaledMin(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapScaledMin,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapScaledMin(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapScaledMin,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapScaledMin(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapScaledMin,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapScaledMin(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapScaledMin,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapPreScaledMin(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapPreScaledMin(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapPreScaledMin(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapPreScaledMin(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScalePolyForwardCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScalePolyForwardCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScalePolyForwardCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScalePolyForwardCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetScalePolyReverseCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScalePolyReverseCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScalePolyReverseCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScalePolyReverseCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetScaleTableScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScaleTableScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScaleTableScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScaleTableScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScaleTableScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScaleTableScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScaleTableScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScaleTableScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetScaleTablePreScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScaleTablePreScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScaleTablePreScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScaleTablePreScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetSysGlobalChans(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysGlobalChans,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysGlobalChans(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysGlobalChans,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
-function DAQmxGetSysScales(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysScales,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysScales(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysScales,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
-function DAQmxGetSysTasks(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysTasks,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysTasks(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysTasks,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
-function DAQmxGetSysDevNames(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysDevNames,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysDevNames(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysDevNames,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
 function DAQmxGetSysNIDAQMajorVersion(data::Ptr{uInt32})
@@ -8074,20 +8074,20 @@ function DAQmxGetSysNIDAQUpdateVersion(data::Ptr{uInt32})
     ccall((:DAQmxGetSysNIDAQUpdateVersion,NIDAQmx),int32,(Ptr{uInt32},),data)
 end
 
-function DAQmxGetTaskName(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetTaskName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetTaskName(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetTaskName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetTaskChannels(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetTaskChannels,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetTaskChannels(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetTaskChannels,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetTaskNumChans(taskHandle::TaskHandle,data::Ptr{uInt32})
     ccall((:DAQmxGetTaskNumChans,NIDAQmx),int32,(TaskHandle,Ptr{uInt32}),taskHandle,data)
 end
 
-function DAQmxGetTaskDevices(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetTaskDevices,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetTaskDevices(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetTaskDevices,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetTaskNumDevices(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -8150,12 +8150,12 @@ function DAQmxGetSampClkMaxRate(taskHandle::TaskHandle,data::Ptr{float64})
     ccall((:DAQmxGetSampClkMaxRate,NIDAQmx),int32,(TaskHandle,Ptr{float64}),taskHandle,data)
 end
 
-function DAQmxGetSampClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSampClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSampClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSampClkSrc(taskHandle::TaskHandle)
@@ -8210,8 +8210,8 @@ function DAQmxResetSampClkTimebaseDiv(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkTimebaseDiv,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetSampClkTimebaseRate(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8226,12 +8226,12 @@ function DAQmxResetSampClkTimebaseRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkTimebaseRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSampClkTimebaseSrc(taskHandle::TaskHandle)
@@ -8262,8 +8262,8 @@ function DAQmxResetSampClkTimebaseMasterTimebaseDiv(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkTimebaseTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkTimebaseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkTimebaseTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkTimebaseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetSampClkDigFltrEnable(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -8290,12 +8290,12 @@ function DAQmxResetSampClkDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -8362,24 +8362,24 @@ function DAQmxResetHshkSampleInputDataWhen(taskHandle::TaskHandle)
     ccall((:DAQmxResetHshkSampleInputDataWhen,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle)
     ccall((:DAQmxResetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle)
@@ -8434,48 +8434,48 @@ function DAQmxResetAIConvRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvMaxRate(taskHandle::TaskHandle,data::Ptr{float64})
     ccall((:DAQmxGetAIConvMaxRate,NIDAQmx),int32,(TaskHandle,Ptr{float64}),taskHandle,data)
 end
 
-function DAQmxGetAIConvMaxRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvMaxRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvMaxRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvMaxRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxGetAIConvSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAIConvSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAIConvSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAIConvSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAIConvSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,deviceNames,data,bufferSize)
+function DAQmxGetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,deviceNames,data,bufferSize)
 end
 
-function DAQmxSetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,deviceNames,data)
+function DAQmxSetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvActiveEdge(taskHandle::TaskHandle,data::Ptr{int32})
@@ -8490,16 +8490,16 @@ function DAQmxResetAIConvActiveEdge(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvActiveEdge,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvTimebaseDiv(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -8514,16 +8514,16 @@ function DAQmxResetAIConvTimebaseDiv(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvTimebaseDiv,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvTimebaseSrc(taskHandle::TaskHandle,data::Ptr{int32})
@@ -8538,16 +8538,16 @@ function DAQmxResetAIConvTimebaseSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvTimebaseSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetDelayFromSampClkDelayUnits(taskHandle::TaskHandle,data::Ptr{int32})
@@ -8562,16 +8562,16 @@ function DAQmxResetDelayFromSampClkDelayUnits(taskHandle::TaskHandle)
     ccall((:DAQmxResetDelayFromSampClkDelayUnits,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,deviceNames,data)
+function DAQmxGetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,data)
+function DAQmxSetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetDelayFromSampClkDelay(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8586,16 +8586,16 @@ function DAQmxResetDelayFromSampClkDelay(taskHandle::TaskHandle)
     ccall((:DAQmxResetDelayFromSampClkDelay,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigFltrEnable(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -8610,16 +8610,16 @@ function DAQmxResetAIConvDigFltrEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigFltrMinPulseWidth(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8634,40 +8634,40 @@ function DAQmxResetAIConvDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
-function DAQmxGetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,deviceNames,data,bufferSize)
+function DAQmxGetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,deviceNames,data,bufferSize)
 end
 
-function DAQmxSetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigFltrTimebaseRate(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8682,16 +8682,16 @@ function DAQmxResetAIConvDigFltrTimebaseRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigSyncEnable(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -8706,16 +8706,16 @@ function DAQmxResetAIConvDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetMasterTimebaseRate(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8730,12 +8730,12 @@ function DAQmxResetMasterTimebaseRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetMasterTimebaseRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetMasterTimebaseSrc(taskHandle::TaskHandle)
@@ -8754,24 +8754,24 @@ function DAQmxResetRefClkRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetRefClkRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetRefClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetRefClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetRefClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetRefClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetRefClkSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetRefClkSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSyncPulseSrc(taskHandle::TaskHandle)
@@ -8810,8 +8810,8 @@ function DAQmxResetSyncPulseResetDelay(taskHandle::TaskHandle)
     ccall((:DAQmxResetSyncPulseResetDelay,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSyncPulseTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSyncPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSyncPulseTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSyncPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetSyncClkInterval(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -8850,16 +8850,16 @@ function DAQmxResetStartTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetStartTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetStartTrigTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetStartTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetStartTrigTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetStartTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeStartTrigSrc(taskHandle::TaskHandle)
@@ -8902,12 +8902,12 @@ function DAQmxResetDigEdgeStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -8938,24 +8938,24 @@ function DAQmxResetDigEdgeStartTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeStartTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternStartTrigSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternStartTrigPattern(taskHandle::TaskHandle)
@@ -8974,12 +8974,12 @@ function DAQmxResetDigPatternStartTrigWhen(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternStartTrigWhen,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle)
@@ -9058,12 +9058,12 @@ function DAQmxResetAnlgEdgeStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9094,12 +9094,12 @@ function DAQmxResetAnlgEdgeStartTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeStartTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinStartTrigSrc(taskHandle::TaskHandle)
@@ -9178,12 +9178,12 @@ function DAQmxResetAnlgWinStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9274,16 +9274,16 @@ function DAQmxResetRefTrigPretrigSamples(taskHandle::TaskHandle)
     ccall((:DAQmxResetRefTrigPretrigSamples,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetRefTrigTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetRefTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetRefTrigTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetRefTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeRefTrigSrc(taskHandle::TaskHandle)
@@ -9326,12 +9326,12 @@ function DAQmxResetDigEdgeRefTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeRefTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9362,24 +9362,24 @@ function DAQmxResetDigEdgeRefTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeRefTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternRefTrigSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternRefTrigPattern(taskHandle::TaskHandle)
@@ -9398,12 +9398,12 @@ function DAQmxResetDigPatternRefTrigWhen(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternRefTrigWhen,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle)
@@ -9482,12 +9482,12 @@ function DAQmxResetAnlgEdgeRefTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeRefTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9518,12 +9518,12 @@ function DAQmxResetAnlgEdgeRefTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeRefTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinRefTrigSrc(taskHandle::TaskHandle)
@@ -9602,12 +9602,12 @@ function DAQmxResetAnlgWinRefTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinRefTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9678,12 +9678,12 @@ function DAQmxResetAdvTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetAdvTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeAdvTrigSrc(taskHandle::TaskHandle)
@@ -9726,12 +9726,12 @@ function DAQmxResetHshkTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetHshkTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetInterlockedHshkTrigSrc(taskHandle::TaskHandle)
@@ -9762,16 +9762,16 @@ function DAQmxResetPauseTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetPauseTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetPauseTrigTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPauseTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetPauseTrigTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPauseTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle)
@@ -9850,12 +9850,12 @@ function DAQmxResetAnlgLvlPauseTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgLvlPauseTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9886,12 +9886,12 @@ function DAQmxResetAnlgLvlPauseTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgLvlPauseTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinPauseTrigSrc(taskHandle::TaskHandle)
@@ -9970,12 +9970,12 @@ function DAQmxResetAnlgWinPauseTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinPauseTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -10006,12 +10006,12 @@ function DAQmxResetAnlgWinPauseTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinPauseTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigLvlPauseTrigSrc(taskHandle::TaskHandle)
@@ -10054,12 +10054,12 @@ function DAQmxResetDigLvlPauseTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigLvlPauseTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -10090,24 +10090,24 @@ function DAQmxResetDigLvlPauseTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigLvlPauseTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternPauseTrigSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternPauseTrigPattern(taskHandle::TaskHandle)
@@ -10138,16 +10138,16 @@ function DAQmxResetArmStartTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetArmStartTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetArmStartTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetArmStartTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetArmStartTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetArmStartTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle)
@@ -10190,12 +10190,12 @@ function DAQmxResetDigEdgeArmStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandl
     ccall((:DAQmxResetDigEdgeArmStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -10274,12 +10274,12 @@ function DAQmxResetWatchdogExpirTrigTrigOnNetworkConnLoss(taskHandle::TaskHandle
     ccall((:DAQmxResetWatchdogExpirTrigTrigOnNetworkConnLoss,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle)
@@ -10298,52 +10298,52 @@ function DAQmxResetDigEdgeWatchdogExpirTrigEdge(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeWatchdogExpirTrigEdge,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,lines,data)
+function DAQmxGetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,lines,data)
 end
 
-function DAQmxSetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,data)
+function DAQmxSetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,data)
 end
 
-function DAQmxResetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8})
-    ccall((:DAQmxResetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,lines)
+function DAQmxResetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8})
+    ccall((:DAQmxResetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,lines)
 end
 
-function DAQmxGetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,lines,data)
+function DAQmxGetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,lines,data)
 end
 
-function DAQmxSetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,data)
+function DAQmxSetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,data)
 end
 
-function DAQmxResetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{Uint8})
-    ccall((:DAQmxResetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,lines)
+function DAQmxResetWatchdogAOOutputType(taskHandle::TaskHandle,lines::Ptr{UInt8})
+    ccall((:DAQmxResetWatchdogAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,lines)
 end
 
-function DAQmxGetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,lines,data)
+function DAQmxGetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,lines,data)
 end
 
-function DAQmxSetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,lines,data)
+function DAQmxSetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,lines,data)
 end
 
-function DAQmxResetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8})
-    ccall((:DAQmxResetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,lines)
+function DAQmxResetWatchdogAOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8})
+    ccall((:DAQmxResetWatchdogAOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,lines)
 end
 
-function DAQmxGetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,lines,data)
+function DAQmxGetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,lines,data)
 end
 
-function DAQmxSetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,data)
+function DAQmxSetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,data)
 end
 
-function DAQmxResetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8})
-    ccall((:DAQmxResetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,lines)
+function DAQmxResetWatchdogCOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8})
+    ccall((:DAQmxResetWatchdogCOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,lines)
 end
 
 function DAQmxGetWatchdogHasExpired(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -10394,40 +10394,40 @@ function DAQmxGetWriteOvercurrentChansExist(taskHandle::TaskHandle,data::Ptr{boo
     ccall((:DAQmxGetWriteOvercurrentChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOvercurrentChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOvercurrentChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteOvertemperatureChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetWriteOvertemperatureChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOvertemperatureChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOvertemperatureChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOvertemperatureChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOvertemperatureChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteOverloadedChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetWriteOverloadedChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOverloadedChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOverloadedChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteOpenCurrentLoopChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetWriteOpenCurrentLoopChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWritePowerSupplyFaultChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetWritePowerSupplyFaultChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWritePowerSupplyFaultChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWritePowerSupplyFaultChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWritePowerSupplyFaultChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWritePowerSupplyFaultChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteSpaceAvail(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -10442,8 +10442,8 @@ function DAQmxGetWriteAccessoryInsertionOrRemovalDetected(taskHandle::TaskHandle
     ccall((:DAQmxGetWriteAccessoryInsertionOrRemovalDetected,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteRawDataWidth(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -10494,180 +10494,180 @@ function DAQmxGetWriteDigitalLinesBytesPerChan(taskHandle::TaskHandle,data::Ptr{
     ccall((:DAQmxGetWriteDigitalLinesBytesPerChan,NIDAQmx),int32,(TaskHandle,Ptr{uInt32}),taskHandle,data)
 end
 
-function DAQmxGetPhysicalChanAISupportedMeasTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanAISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanAISupportedMeasTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanAISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanAITermCfgs(physicalChannel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetPhysicalChanAITermCfgs,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAITermCfgs(physicalChannel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetPhysicalChanAITermCfgs,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAIInputSrcs(physicalChannel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPhysicalChanAIInputSrcs,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),physicalChannel,data,bufferSize)
+function DAQmxGetPhysicalChanAIInputSrcs(physicalChannel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPhysicalChanAIInputSrcs,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),physicalChannel,data,bufferSize)
 end
 
-function DAQmxGetPhysicalChanAOSupportedOutputTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanAOSupportedOutputTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanAOSupportedPowerUpOutputTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanAOSupportedPowerUpOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanAOSupportedPowerUpOutputTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanAOSupportedPowerUpOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanAOTermCfgs(physicalChannel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetPhysicalChanAOTermCfgs,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOTermCfgs(physicalChannel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetPhysicalChanAOTermCfgs,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxSetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{Uint8},bool32),physicalChannel,data)
+function DAQmxSetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{UInt8},bool32),physicalChannel,data)
 end
 
-function DAQmxResetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{Uint8})
-    ccall((:DAQmxResetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{Uint8},),physicalChannel)
+function DAQmxResetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{UInt8})
+    ccall((:DAQmxResetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{UInt8},),physicalChannel)
 end
 
-function DAQmxGetPhysicalChanAOManualControlShortDetected(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanAOManualControlShortDetected,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlShortDetected(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanAOManualControlShortDetected,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAOManualControlAmplitude(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetPhysicalChanAOManualControlAmplitude,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlAmplitude(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetPhysicalChanAOManualControlAmplitude,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAOManualControlFreq(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetPhysicalChanAOManualControlFreq,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlFreq(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetPhysicalChanAOManualControlFreq,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetAOPowerAmpChannelEnable(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetAOPowerAmpChannelEnable(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxSetAOPowerAmpChannelEnable(physicalChannel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{Uint8},bool32),physicalChannel,data)
+function DAQmxSetAOPowerAmpChannelEnable(physicalChannel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{UInt8},bool32),physicalChannel,data)
 end
 
-function DAQmxResetAOPowerAmpChannelEnable(physicalChannel::Ptr{Uint8})
-    ccall((:DAQmxResetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{Uint8},),physicalChannel)
+function DAQmxResetAOPowerAmpChannelEnable(physicalChannel::Ptr{UInt8})
+    ccall((:DAQmxResetAOPowerAmpChannelEnable,NIDAQmx),int32,(Ptr{UInt8},),physicalChannel)
 end
 
-function DAQmxGetAOPowerAmpScalingCoeff(physicalChannel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAOPowerAmpScalingCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetAOPowerAmpScalingCoeff(physicalChannel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAOPowerAmpScalingCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetAOPowerAmpOvercurrent(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOPowerAmpOvercurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetAOPowerAmpOvercurrent(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOPowerAmpOvercurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetAOPowerAmpGain(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOPowerAmpGain,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetAOPowerAmpGain(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOPowerAmpGain,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetAOPowerAmpOffset(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOPowerAmpOffset,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetAOPowerAmpOffset(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOPowerAmpOffset,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDIPortWidth(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanDIPortWidth,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDIPortWidth(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanDIPortWidth,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDISampClkSupported(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanDISampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDISampClkSupported(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanDISampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDISampModes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanDISampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanDISampModes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanDISampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanDIChangeDetectSupported(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanDIChangeDetectSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDIChangeDetectSupported(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanDIChangeDetectSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDOPortWidth(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanDOPortWidth,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDOPortWidth(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanDOPortWidth,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDOSampClkSupported(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanDOSampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDOSampClkSupported(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanDOSampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDOSampModes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanDOSampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanDOSampModes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanDOSampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanCISupportedMeasTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanCISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanCISupportedMeasTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanCISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanCOSupportedOutputTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanCOSupportedOutputTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanTEDSMfgID(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSMfgID,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSMfgID(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSMfgID,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSModelNum(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSModelNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSModelNum(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSModelNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSSerialNum(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSSerialNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSSerialNum(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSSerialNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSVersionNum(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSVersionNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSVersionNum(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSVersionNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSVersionLetter(physicalChannel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPhysicalChanTEDSVersionLetter,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),physicalChannel,data,bufferSize)
+function DAQmxGetPhysicalChanTEDSVersionLetter(physicalChannel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPhysicalChanTEDSVersionLetter,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),physicalChannel,data,bufferSize)
 end
 
-function DAQmxGetPhysicalChanTEDSBitStream(physicalChannel::Ptr{Uint8},data::Ptr{uInt8},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanTEDSBitStream,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt8},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanTEDSBitStream(physicalChannel::Ptr{UInt8},data::Ptr{uInt8},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanTEDSBitStream,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt8},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanTEDSTemplateIDs(physicalChannel::Ptr{Uint8},data::Ptr{uInt32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanTEDSTemplateIDs,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanTEDSTemplateIDs(physicalChannel::Ptr{UInt8},data::Ptr{uInt32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanTEDSTemplateIDs,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPersistedTaskAuthor(taskName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPersistedTaskAuthor,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),taskName,data,bufferSize)
+function DAQmxGetPersistedTaskAuthor(taskName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPersistedTaskAuthor,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),taskName,data,bufferSize)
 end
 
-function DAQmxGetPersistedTaskAllowInteractiveEditing(taskName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedTaskAllowInteractiveEditing,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),taskName,data)
+function DAQmxGetPersistedTaskAllowInteractiveEditing(taskName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedTaskAllowInteractiveEditing,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),taskName,data)
 end
 
-function DAQmxGetPersistedTaskAllowInteractiveDeletion(taskName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedTaskAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),taskName,data)
+function DAQmxGetPersistedTaskAllowInteractiveDeletion(taskName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedTaskAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),taskName,data)
 end
 
-function DAQmxGetPersistedChanAuthor(channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPersistedChanAuthor,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),channel,data,bufferSize)
+function DAQmxGetPersistedChanAuthor(channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPersistedChanAuthor,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),channel,data,bufferSize)
 end
 
-function DAQmxGetPersistedChanAllowInteractiveEditing(channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedChanAllowInteractiveEditing,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),channel,data)
+function DAQmxGetPersistedChanAllowInteractiveEditing(channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedChanAllowInteractiveEditing,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),channel,data)
 end
 
-function DAQmxGetPersistedChanAllowInteractiveDeletion(channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedChanAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),channel,data)
+function DAQmxGetPersistedChanAllowInteractiveDeletion(channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedChanAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),channel,data)
 end
 
-function DAQmxGetPersistedScaleAuthor(scaleName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPersistedScaleAuthor,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,data,bufferSize)
+function DAQmxGetPersistedScaleAuthor(scaleName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPersistedScaleAuthor,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,data,bufferSize)
 end
 
-function DAQmxGetPersistedScaleAllowInteractiveEditing(scaleName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedScaleAllowInteractiveEditing,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),scaleName,data)
+function DAQmxGetPersistedScaleAllowInteractiveEditing(scaleName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedScaleAllowInteractiveEditing,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),scaleName,data)
 end
 
-function DAQmxGetPersistedScaleAllowInteractiveDeletion(scaleName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedScaleAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),scaleName,data)
+function DAQmxGetPersistedScaleAllowInteractiveDeletion(scaleName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedScaleAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),scaleName,data)
 end
 
 function DAQmxGetSampClkTimingResponseMode(taskHandle::TaskHandle,data::Ptr{int32})

--- a/src/functions_V9.6.0.jl
+++ b/src/functions_V9.6.0.jl
@@ -2,16 +2,16 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function DAQmxLoadTask(taskName::Ptr{Uint8},taskHandle::Ptr{TaskHandle})
-    ccall((:DAQmxLoadTask,NIDAQmx),int32,(Ptr{Uint8},Ptr{TaskHandle}),taskName,taskHandle)
+function DAQmxLoadTask(taskName::Ptr{UInt8},taskHandle::Ptr{TaskHandle})
+    ccall((:DAQmxLoadTask,NIDAQmx),int32,(Ptr{UInt8},Ptr{TaskHandle}),taskName,taskHandle)
 end
 
-function DAQmxCreateTask(taskName::Ptr{Uint8},taskHandle::Ptr{TaskHandle})
-    ccall((:DAQmxCreateTask,NIDAQmx),int32,(Ptr{Uint8},Ptr{TaskHandle}),taskName,taskHandle)
+function DAQmxCreateTask(taskName::Ptr{UInt8},taskHandle::Ptr{TaskHandle})
+    ccall((:DAQmxCreateTask,NIDAQmx),int32,(Ptr{UInt8},Ptr{TaskHandle}),taskName,taskHandle)
 end
 
-function DAQmxAddGlobalChansToTask(taskHandle::TaskHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAddGlobalChansToTask,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channelNames)
+function DAQmxAddGlobalChansToTask(taskHandle::TaskHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAddGlobalChansToTask,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channelNames)
 end
 
 function DAQmxStartTask(taskHandle::TaskHandle)
@@ -38,12 +38,12 @@ function DAQmxTaskControl(taskHandle::TaskHandle,action::int32)
     ccall((:DAQmxTaskControl,NIDAQmx),int32,(TaskHandle,int32),taskHandle,action)
 end
 
-function DAQmxGetNthTaskChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{Uint8},bufferSize::int32)
-    ccall((:DAQmxGetNthTaskChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{Uint8},int32),taskHandle,index,buffer,bufferSize)
+function DAQmxGetNthTaskChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{UInt8},bufferSize::int32)
+    ccall((:DAQmxGetNthTaskChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{UInt8},int32),taskHandle,index,buffer,bufferSize)
 end
 
-function DAQmxGetNthTaskDevice(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{Uint8},bufferSize::int32)
-    ccall((:DAQmxGetNthTaskDevice,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{Uint8},int32),taskHandle,index,buffer,bufferSize)
+function DAQmxGetNthTaskDevice(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{UInt8},bufferSize::int32)
+    ccall((:DAQmxGetNthTaskDevice,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{UInt8},int32),taskHandle,index,buffer,bufferSize)
 end
 
 function DAQmxRegisterEveryNSamplesEvent(task::TaskHandle,everyNsamplesEventType::int32,nSamples::uInt32,options::uInt32,callbackFunction::DAQmxEveryNSamplesEventCallbackPtr,callbackData::Ptr{Void})
@@ -58,388 +58,388 @@ function DAQmxRegisterSignalEvent(task::TaskHandle,signalID::int32,options::uInt
     ccall((:DAQmxRegisterSignalEvent,NIDAQmx),int32,(TaskHandle,int32,uInt32,DAQmxSignalEventCallbackPtr,Ptr{Void}),task,signalID,options,callbackFunction,callbackData)
 end
 
-function DAQmxCreateAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
+function DAQmxCreateAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
 end
 
-function DAQmxCreateAIVoltageRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVoltageRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAIVoltageRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVoltageRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAICurrentRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAICurrentRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
+function DAQmxCreateAICurrentRMSChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAICurrentRMSChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
 end
 
-function DAQmxCreateAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,thermocoupleType::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{Uint8})
-    ccall((:DAQmxCreateAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thermocoupleType,cjcSource,cjcVal,cjcChannel)
+function DAQmxCreateAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,thermocoupleType::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{UInt8})
+    ccall((:DAQmxCreateAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thermocoupleType,cjcSource,cjcVal,cjcChannel)
 end
 
-function DAQmxCreateAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,rtdType::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,r0::float64)
-    ccall((:DAQmxCreateAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,rtdType,resistanceConfig,currentExcitSource,currentExcitVal,r0)
+function DAQmxCreateAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,rtdType::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,r0::float64)
+    ccall((:DAQmxCreateAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,rtdType,resistanceConfig,currentExcitSource,currentExcitVal,r0)
 end
 
-function DAQmxCreateAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,a::float64,b::float64,c::float64)
-    ccall((:DAQmxCreateAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,a,b,c)
+function DAQmxCreateAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,a::float64,b::float64,c::float64)
+    ccall((:DAQmxCreateAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,a,b,c)
 end
 
-function DAQmxCreateAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,a::float64,b::float64,c::float64,r1::float64)
-    ccall((:DAQmxCreateAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,a,b,c,r1)
+function DAQmxCreateAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,a::float64,b::float64,c::float64,r1::float64)
+    ccall((:DAQmxCreateAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,a,b,c,r1)
 end
 
-function DAQmxCreateAIFreqVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,thresholdLevel::float64,hysteresis::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIFreqVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thresholdLevel,hysteresis,customScaleName)
+function DAQmxCreateAIFreqVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,thresholdLevel::float64,hysteresis::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIFreqVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,thresholdLevel,hysteresis,customScaleName)
 end
 
-function DAQmxCreateAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,initialBridgeVoltage::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,initialBridgeVoltage,nominalGageResistance,poissonRatio,leadWireResistance,customScaleName)
+function DAQmxCreateAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,initialBridgeVoltage::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,initialBridgeVoltage,nominalGageResistance,poissonRatio,leadWireResistance,customScaleName)
 end
 
-function DAQmxCreateAIRosetteStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,rosetteType::int32,gageOrientation::float64,rosetteMeasTypes::Ptr{int32},numRosetteMeasTypes::uInt32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64)
-    ccall((:DAQmxCreateAIRosetteStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,Ptr{int32},uInt32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,rosetteType,gageOrientation,rosetteMeasTypes,numRosetteMeasTypes,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,nominalGageResistance,poissonRatio,leadWireResistance)
+function DAQmxCreateAIRosetteStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,rosetteType::int32,gageOrientation::float64,rosetteMeasTypes::Ptr{int32},numRosetteMeasTypes::uInt32,strainConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,gageFactor::float64,nominalGageResistance::float64,poissonRatio::float64,leadWireResistance::float64)
+    ccall((:DAQmxCreateAIRosetteStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,Ptr{int32},uInt32,int32,int32,float64,float64,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,rosetteType,gageOrientation,rosetteMeasTypes,numRosetteMeasTypes,strainConfig,voltageExcitSource,voltageExcitVal,gageFactor,nominalGageResistance,poissonRatio,leadWireResistance)
 end
 
-function DAQmxCreateAIForceBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
+function DAQmxCreateAIForceBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIForceBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
+function DAQmxCreateAIForceBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIForceBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
+function DAQmxCreateAIForceBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIPressureBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPressureBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
+function DAQmxCreateAIPressureBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPressureBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIPressureBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPressureBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
+function DAQmxCreateAIPressureBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPressureBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIPressureBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPressureBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
+function DAQmxCreateAIPressureBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPressureBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAITorqueBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAITorqueBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
+function DAQmxCreateAITorqueBridgeTwoPointLinChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,firstElectricalVal::float64,secondElectricalVal::float64,electricalUnits::int32,firstPhysicalVal::float64,secondPhysicalVal::float64,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAITorqueBridgeTwoPointLinChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,float64,float64,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,firstElectricalVal,secondElectricalVal,electricalUnits,firstPhysicalVal,secondPhysicalVal,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAITorqueBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAITorqueBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
+function DAQmxCreateAITorqueBridgeTableChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,electricalVals::Ptr{float64},numElectricalVals::uInt32,electricalUnits::int32,physicalVals::Ptr{float64},numPhysicalVals::uInt32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAITorqueBridgeTableChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,int32,Ptr{float64},uInt32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,electricalVals,numElectricalVals,electricalUnits,physicalVals,numPhysicalVals,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAITorqueBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAITorqueBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
+function DAQmxCreateAITorqueBridgePolynomialChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,forwardCoeffs::Ptr{float64},numForwardCoeffs::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffs::uInt32,electricalUnits::int32,physicalUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAITorqueBridgePolynomialChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{float64},uInt32,Ptr{float64},uInt32,int32,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,forwardCoeffs,numForwardCoeffs,reverseCoeffs,numReverseCoeffs,electricalUnits,physicalUnits,customScaleName)
 end
 
-function DAQmxCreateAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,customScaleName)
+function DAQmxCreateAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,nominalBridgeResistance::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,nominalBridgeResistance,customScaleName)
 end
 
-function DAQmxCreateAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,useExcitForScaling::bool32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,int32,float64,bool32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,useExcitForScaling,customScaleName)
+function DAQmxCreateAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,bridgeConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,useExcitForScaling::bool32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,int32,float64,bool32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,bridgeConfig,voltageExcitSource,voltageExcitVal,useExcitForScaling,customScaleName)
 end
 
-function DAQmxCreateAITempBuiltInSensorChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32)
-    ccall((:DAQmxCreateAITempBuiltInSensorChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
+function DAQmxCreateAITempBuiltInSensorChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32)
+    ccall((:DAQmxCreateAITempBuiltInSensorChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
 end
 
-function DAQmxCreateAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIVelocityIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIVelocityIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIVelocityIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIVelocityIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,sensitivity,sensitivityUnits,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,units::int32,micSensitivity::float64,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,float64,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,micSensitivity,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,units::int32,micSensitivity::float64,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,float64,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,micSensitivity,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateAIPosEddyCurrProxProbeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAIPosEddyCurrProxProbeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,customScaleName)
+function DAQmxCreateAIPosEddyCurrProxProbeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,sensitivity::float64,sensitivityUnits::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAIPosEddyCurrProxProbeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,sensitivity,sensitivityUnits,customScaleName)
 end
 
-function DAQmxCreateAIDeviceTempChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32)
-    ccall((:DAQmxCreateAIDeviceTempChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
+function DAQmxCreateAIDeviceTempChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32)
+    ccall((:DAQmxCreateAIDeviceTempChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,physicalChannel,nameToAssignToChannel,units)
 end
 
-function DAQmxCreateTEDSAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
+function DAQmxCreateTEDSAIVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateTEDSAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
+function DAQmxCreateTEDSAICurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,shuntResistorLoc::int32,extShuntResistorVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAICurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,shuntResistorLoc,extShuntResistorVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,cjcSource,cjcVal,cjcChannel)
+function DAQmxCreateTEDSAIThrmcplChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,cjcSource::int32,cjcVal::float64,cjcChannel::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIThrmcplChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,cjcSource,cjcVal,cjcChannel)
 end
 
-function DAQmxCreateTEDSAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
-    ccall((:DAQmxCreateTEDSAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
+function DAQmxCreateTEDSAIRTDChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
+    ccall((:DAQmxCreateTEDSAIRTDChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
 end
 
-function DAQmxCreateTEDSAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
-    ccall((:DAQmxCreateTEDSAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
+function DAQmxCreateTEDSAIThrmstrChanIex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64)
+    ccall((:DAQmxCreateTEDSAIThrmstrChanIex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal)
 end
 
-function DAQmxCreateTEDSAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,r1::float64)
-    ccall((:DAQmxCreateTEDSAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,r1)
+function DAQmxCreateTEDSAIThrmstrChanVex(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,voltageExcitSource::int32,voltageExcitVal::float64,r1::float64)
+    ccall((:DAQmxCreateTEDSAIThrmstrChanVex,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,voltageExcitSource,voltageExcitVal,r1)
 end
 
-function DAQmxCreateTEDSAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIResistanceChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,resistanceConfig::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIResistanceChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,resistanceConfig,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,initialBridgeVoltage::float64,leadWireResistance::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,float64,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,initialBridgeVoltage,leadWireResistance,customScaleName)
+function DAQmxCreateTEDSAIStrainGageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,initialBridgeVoltage::float64,leadWireResistance::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIStrainGageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,float64,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,initialBridgeVoltage,leadWireResistance,customScaleName)
 end
 
-function DAQmxCreateTEDSAIForceBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIForceBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIForceBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIForceBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIPressureBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIPressureBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIPressureBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIPressureBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAITorqueBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAITorqueBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAITorqueBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAITorqueBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIBridgeChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIBridgeChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
+function DAQmxCreateTEDSAIVoltageChanWithExcit(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIVoltageChanWithExcit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIAccelChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIAccelChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,int32,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIForceIEPEChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,minVal::float64,maxVal::float64,units::int32,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIForceIEPEChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,int32,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,minVal,maxVal,units,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},terminalConfig::int32,units::int32,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,int32,float64,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
+function DAQmxCreateTEDSAIMicrophoneChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},terminalConfig::int32,units::int32,maxSndPressLevel::float64,currentExcitSource::int32,currentExcitVal::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIMicrophoneChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,int32,float64,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,terminalConfig,units,maxSndPressLevel,currentExcitSource,currentExcitVal,customScaleName)
 end
 
-function DAQmxCreateTEDSAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateTEDSAIPosLVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIPosLVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateTEDSAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateTEDSAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
+function DAQmxCreateTEDSAIPosRVDTChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,voltageExcitSource::int32,voltageExcitVal::float64,voltageExcitFreq::float64,ACExcitWireMode::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateTEDSAIPosRVDTChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,voltageExcitSource,voltageExcitVal,voltageExcitFreq,ACExcitWireMode,customScaleName)
 end
 
-function DAQmxCreateAOVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAOVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAOVoltageChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAOVoltageChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAOCurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateAOCurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
+function DAQmxCreateAOCurrentChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateAOCurrentChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),taskHandle,physicalChannel,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateAOFuncGenChan(taskHandle::TaskHandle,physicalChannel::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},_type::int32,freq::float64,amplitude::float64,offset::float64)
-    ccall((:DAQmxCreateAOFuncGenChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,_type,freq,amplitude,offset)
+function DAQmxCreateAOFuncGenChan(taskHandle::TaskHandle,physicalChannel::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},_type::int32,freq::float64,amplitude::float64,offset::float64)
+    ccall((:DAQmxCreateAOFuncGenChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,float64,float64,float64),taskHandle,physicalChannel,nameToAssignToChannel,_type,freq,amplitude,offset)
 end
 
-function DAQmxCreateDIChan(taskHandle::TaskHandle,lines::Ptr{Uint8},nameToAssignToLines::Ptr{Uint8},lineGrouping::int32)
-    ccall((:DAQmxCreateDIChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
+function DAQmxCreateDIChan(taskHandle::TaskHandle,lines::Ptr{UInt8},nameToAssignToLines::Ptr{UInt8},lineGrouping::int32)
+    ccall((:DAQmxCreateDIChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
 end
 
-function DAQmxCreateDOChan(taskHandle::TaskHandle,lines::Ptr{Uint8},nameToAssignToLines::Ptr{Uint8},lineGrouping::int32)
-    ccall((:DAQmxCreateDOChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
+function DAQmxCreateDOChan(taskHandle::TaskHandle,lines::Ptr{UInt8},nameToAssignToLines::Ptr{UInt8},lineGrouping::int32)
+    ccall((:DAQmxCreateDOChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,lines,nameToAssignToLines,lineGrouping)
 end
 
-function DAQmxCreateCIFreqChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIFreqChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
+function DAQmxCreateCIFreqChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIFreqChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
 end
 
-function DAQmxCreateCIPeriodChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
+function DAQmxCreateCIPeriodChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,edge::int32,measMethod::int32,measTime::float64,divisor::uInt32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,float64,uInt32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,edge,measMethod,measTime,divisor,customScaleName)
 end
 
-function DAQmxCreateCICountEdgesChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},edge::int32,initialCount::uInt32,countDirection::int32)
-    ccall((:DAQmxCreateCICountEdgesChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,uInt32,int32),taskHandle,counter,nameToAssignToChannel,edge,initialCount,countDirection)
+function DAQmxCreateCICountEdgesChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},edge::int32,initialCount::uInt32,countDirection::int32)
+    ccall((:DAQmxCreateCICountEdgesChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,uInt32,int32),taskHandle,counter,nameToAssignToChannel,edge,initialCount,countDirection)
 end
 
-function DAQmxCreateCIPulseWidthChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,startingEdge::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIPulseWidthChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,startingEdge,customScaleName)
+function DAQmxCreateCIPulseWidthChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,startingEdge::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIPulseWidthChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,startingEdge,customScaleName)
 end
 
-function DAQmxCreateCISemiPeriodChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCISemiPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
+function DAQmxCreateCISemiPeriodChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCISemiPeriodChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,customScaleName)
 end
 
-function DAQmxCreateCITwoEdgeSepChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32,firstEdge::int32,secondEdge::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCITwoEdgeSepChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32,int32,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,firstEdge,secondEdge,customScaleName)
+function DAQmxCreateCITwoEdgeSepChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32,firstEdge::int32,secondEdge::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCITwoEdgeSepChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32,int32,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units,firstEdge,secondEdge,customScaleName)
 end
 
-function DAQmxCreateCIPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32)
-    ccall((:DAQmxCreateCIPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
+function DAQmxCreateCIPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32)
+    ccall((:DAQmxCreateCIPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
 end
 
-function DAQmxCreateCIPulseChanTime(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},minVal::float64,maxVal::float64,units::int32)
-    ccall((:DAQmxCreateCIPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
+function DAQmxCreateCIPulseChanTime(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},minVal::float64,maxVal::float64,units::int32)
+    ccall((:DAQmxCreateCIPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},float64,float64,int32),taskHandle,counter,nameToAssignToChannel,minVal,maxVal,units)
 end
 
-function DAQmxCreateCIPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},sourceTerminal::Ptr{Uint8},minVal::float64,maxVal::float64)
-    ccall((:DAQmxCreateCIPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},float64,float64),taskHandle,counter,nameToAssignToChannel,sourceTerminal,minVal,maxVal)
+function DAQmxCreateCIPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},sourceTerminal::Ptr{UInt8},minVal::float64,maxVal::float64)
+    ccall((:DAQmxCreateCIPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},float64,float64),taskHandle,counter,nameToAssignToChannel,sourceTerminal,minVal,maxVal)
 end
 
-function DAQmxCreateCILinEncoderChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,distPerPulse::float64,initialPos::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCILinEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,bool32,float64,int32,int32,float64,float64,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,distPerPulse,initialPos,customScaleName)
+function DAQmxCreateCILinEncoderChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,distPerPulse::float64,initialPos::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCILinEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,bool32,float64,int32,int32,float64,float64,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,distPerPulse,initialPos,customScaleName)
 end
 
-function DAQmxCreateCIAngEncoderChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,pulsesPerRev::uInt32,initialAngle::float64,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIAngEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,bool32,float64,int32,int32,uInt32,float64,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,pulsesPerRev,initialAngle,customScaleName)
+function DAQmxCreateCIAngEncoderChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},decodingType::int32,ZidxEnable::bool32,ZidxVal::float64,ZidxPhase::int32,units::int32,pulsesPerRev::uInt32,initialAngle::float64,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIAngEncoderChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,bool32,float64,int32,int32,uInt32,float64,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,decodingType,ZidxEnable,ZidxVal,ZidxPhase,units,pulsesPerRev,initialAngle,customScaleName)
 end
 
-function DAQmxCreateCIGPSTimestampChan(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32,syncMethod::int32,customScaleName::Ptr{Uint8})
-    ccall((:DAQmxCreateCIGPSTimestampChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,Ptr{Uint8}),taskHandle,counter,nameToAssignToChannel,units,syncMethod,customScaleName)
+function DAQmxCreateCIGPSTimestampChan(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32,syncMethod::int32,customScaleName::Ptr{UInt8})
+    ccall((:DAQmxCreateCIGPSTimestampChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,Ptr{UInt8}),taskHandle,counter,nameToAssignToChannel,units,syncMethod,customScaleName)
 end
 
-function DAQmxCreateCOPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32,idleState::int32,initialDelay::float64,freq::float64,dutyCycle::float64)
-    ccall((:DAQmxCreateCOPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,freq,dutyCycle)
+function DAQmxCreateCOPulseChanFreq(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32,idleState::int32,initialDelay::float64,freq::float64,dutyCycle::float64)
+    ccall((:DAQmxCreateCOPulseChanFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,freq,dutyCycle)
 end
 
-function DAQmxCreateCOPulseChanTime(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},units::int32,idleState::int32,initialDelay::float64,lowTime::float64,highTime::float64)
-    ccall((:DAQmxCreateCOPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,lowTime,highTime)
+function DAQmxCreateCOPulseChanTime(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},units::int32,idleState::int32,initialDelay::float64,lowTime::float64,highTime::float64)
+    ccall((:DAQmxCreateCOPulseChanTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,int32,float64,float64,float64),taskHandle,counter,nameToAssignToChannel,units,idleState,initialDelay,lowTime,highTime)
 end
 
-function DAQmxCreateCOPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{Uint8},nameToAssignToChannel::Ptr{Uint8},sourceTerminal::Ptr{Uint8},idleState::int32,initialDelay::int32,lowTicks::int32,highTicks::int32)
-    ccall((:DAQmxCreateCOPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},int32,int32,int32,int32),taskHandle,counter,nameToAssignToChannel,sourceTerminal,idleState,initialDelay,lowTicks,highTicks)
+function DAQmxCreateCOPulseChanTicks(taskHandle::TaskHandle,counter::Ptr{UInt8},nameToAssignToChannel::Ptr{UInt8},sourceTerminal::Ptr{UInt8},idleState::int32,initialDelay::int32,lowTicks::int32,highTicks::int32)
+    ccall((:DAQmxCreateCOPulseChanTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},int32,int32,int32,int32),taskHandle,counter,nameToAssignToChannel,sourceTerminal,idleState,initialDelay,lowTicks,highTicks)
 end
 
-function DAQmxGetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxGetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxSetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
-    ccall((:DAQmxSetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxSetAIChanCalCalDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
+    ccall((:DAQmxSetAIChanCalCalDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxGetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxGetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxSetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{Uint8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
-    ccall((:DAQmxSetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
+function DAQmxSetAIChanCalExpDate(taskHandle::TaskHandle,channelName::Ptr{UInt8},year::uInt32,month::uInt32,day::uInt32,hour::uInt32,minute::uInt32)
+    ccall((:DAQmxSetAIChanCalExpDate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32,uInt32,uInt32,uInt32,uInt32),taskHandle,channelName,year,month,day,hour,minute)
 end
 
-function DAQmxResetChanAttribute(taskHandle::TaskHandle,channel::Ptr{Uint8},attribute::int32)
-    ccall((:DAQmxResetChanAttribute,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,attribute)
+function DAQmxResetChanAttribute(taskHandle::TaskHandle,channel::Ptr{UInt8},attribute::int32)
+    ccall((:DAQmxResetChanAttribute,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,attribute)
 end
 
-function DAQmxCfgSampClkTiming(taskHandle::TaskHandle,source::Ptr{Uint8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
-    ccall((:DAQmxCfgSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
+function DAQmxCfgSampClkTiming(taskHandle::TaskHandle,source::Ptr{UInt8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
+    ccall((:DAQmxCfgSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
 end
 
 function DAQmxCfgHandshakingTiming(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64)
     ccall((:DAQmxCfgHandshakingTiming,NIDAQmx),int32,(TaskHandle,int32,uInt64),taskHandle,sampleMode,sampsPerChan)
 end
 
-function DAQmxCfgBurstHandshakingTimingImportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkSrc::Ptr{Uint8},sampleClkActiveEdge::int32,pauseWhen::int32,readyEventActiveLevel::int32)
-    ccall((:DAQmxCfgBurstHandshakingTimingImportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{Uint8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkSrc,sampleClkActiveEdge,pauseWhen,readyEventActiveLevel)
+function DAQmxCfgBurstHandshakingTimingImportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkSrc::Ptr{UInt8},sampleClkActiveEdge::int32,pauseWhen::int32,readyEventActiveLevel::int32)
+    ccall((:DAQmxCfgBurstHandshakingTimingImportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{UInt8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkSrc,sampleClkActiveEdge,pauseWhen,readyEventActiveLevel)
 end
 
-function DAQmxCfgBurstHandshakingTimingExportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkOutpTerm::Ptr{Uint8},sampleClkPulsePolarity::int32,pauseWhen::int32,readyEventActiveLevel::int32)
-    ccall((:DAQmxCfgBurstHandshakingTimingExportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{Uint8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkOutpTerm,sampleClkPulsePolarity,pauseWhen,readyEventActiveLevel)
+function DAQmxCfgBurstHandshakingTimingExportClock(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64,sampleClkRate::float64,sampleClkOutpTerm::Ptr{UInt8},sampleClkPulsePolarity::int32,pauseWhen::int32,readyEventActiveLevel::int32)
+    ccall((:DAQmxCfgBurstHandshakingTimingExportClock,NIDAQmx),int32,(TaskHandle,int32,uInt64,float64,Ptr{UInt8},int32,int32,int32),taskHandle,sampleMode,sampsPerChan,sampleClkRate,sampleClkOutpTerm,sampleClkPulsePolarity,pauseWhen,readyEventActiveLevel)
 end
 
-function DAQmxCfgChangeDetectionTiming(taskHandle::TaskHandle,risingEdgeChan::Ptr{Uint8},fallingEdgeChan::Ptr{Uint8},sampleMode::int32,sampsPerChan::uInt64)
-    ccall((:DAQmxCfgChangeDetectionTiming,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,uInt64),taskHandle,risingEdgeChan,fallingEdgeChan,sampleMode,sampsPerChan)
+function DAQmxCfgChangeDetectionTiming(taskHandle::TaskHandle,risingEdgeChan::Ptr{UInt8},fallingEdgeChan::Ptr{UInt8},sampleMode::int32,sampsPerChan::uInt64)
+    ccall((:DAQmxCfgChangeDetectionTiming,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,uInt64),taskHandle,risingEdgeChan,fallingEdgeChan,sampleMode,sampsPerChan)
 end
 
 function DAQmxCfgImplicitTiming(taskHandle::TaskHandle,sampleMode::int32,sampsPerChan::uInt64)
     ccall((:DAQmxCfgImplicitTiming,NIDAQmx),int32,(TaskHandle,int32,uInt64),taskHandle,sampleMode,sampsPerChan)
 end
 
-function DAQmxCfgPipelinedSampClkTiming(taskHandle::TaskHandle,source::Ptr{Uint8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
-    ccall((:DAQmxCfgPipelinedSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
+function DAQmxCfgPipelinedSampClkTiming(taskHandle::TaskHandle,source::Ptr{UInt8},rate::float64,activeEdge::int32,sampleMode::int32,sampsPerChan::uInt64)
+    ccall((:DAQmxCfgPipelinedSampClkTiming,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,int32,uInt64),taskHandle,source,rate,activeEdge,sampleMode,sampsPerChan)
 end
 
 function DAQmxResetTimingAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetTimingAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxResetTimingAttributeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},attribute::int32)
-    ccall((:DAQmxResetTimingAttributeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,attribute)
+function DAQmxResetTimingAttributeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},attribute::int32)
+    ccall((:DAQmxResetTimingAttributeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,attribute)
 end
 
 function DAQmxDisableStartTrig(taskHandle::TaskHandle)
     ccall((:DAQmxDisableStartTrig,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxCfgDigEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerEdge::int32)
-    ccall((:DAQmxCfgDigEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,triggerSource,triggerEdge)
+function DAQmxCfgDigEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerEdge::int32)
+    ccall((:DAQmxCfgDigEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,triggerSource,triggerEdge)
 end
 
-function DAQmxCfgAnlgEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerSlope::int32,triggerLevel::float64)
-    ccall((:DAQmxCfgAnlgEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64),taskHandle,triggerSource,triggerSlope,triggerLevel)
+function DAQmxCfgAnlgEdgeStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerSlope::int32,triggerLevel::float64)
+    ccall((:DAQmxCfgAnlgEdgeStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64),taskHandle,triggerSource,triggerSlope,triggerLevel)
 end
 
-function DAQmxCfgAnlgWindowStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerWhen::int32,windowTop::float64,windowBottom::float64)
-    ccall((:DAQmxCfgAnlgWindowStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64,float64),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom)
+function DAQmxCfgAnlgWindowStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerWhen::int32,windowTop::float64,windowBottom::float64)
+    ccall((:DAQmxCfgAnlgWindowStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64,float64),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom)
 end
 
-function DAQmxCfgDigPatternStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerPattern::Ptr{Uint8},triggerWhen::int32)
-    ccall((:DAQmxCfgDigPatternStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32),taskHandle,triggerSource,triggerPattern,triggerWhen)
+function DAQmxCfgDigPatternStartTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerPattern::Ptr{UInt8},triggerWhen::int32)
+    ccall((:DAQmxCfgDigPatternStartTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32),taskHandle,triggerSource,triggerPattern,triggerWhen)
 end
 
 function DAQmxDisableRefTrig(taskHandle::TaskHandle)
     ccall((:DAQmxDisableRefTrig,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxCfgDigEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerEdge::int32,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgDigEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,uInt32),taskHandle,triggerSource,triggerEdge,pretriggerSamples)
+function DAQmxCfgDigEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerEdge::int32,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgDigEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,uInt32),taskHandle,triggerSource,triggerEdge,pretriggerSamples)
 end
 
-function DAQmxCfgAnlgEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerSlope::int32,triggerLevel::float64,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgAnlgEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64,uInt32),taskHandle,triggerSource,triggerSlope,triggerLevel,pretriggerSamples)
+function DAQmxCfgAnlgEdgeRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerSlope::int32,triggerLevel::float64,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgAnlgEdgeRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64,uInt32),taskHandle,triggerSource,triggerSlope,triggerLevel,pretriggerSamples)
 end
 
-function DAQmxCfgAnlgWindowRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerWhen::int32,windowTop::float64,windowBottom::float64,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgAnlgWindowRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,float64,float64,uInt32),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom,pretriggerSamples)
+function DAQmxCfgAnlgWindowRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerWhen::int32,windowTop::float64,windowBottom::float64,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgAnlgWindowRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,float64,float64,uInt32),taskHandle,triggerSource,triggerWhen,windowTop,windowBottom,pretriggerSamples)
 end
 
-function DAQmxCfgDigPatternRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerPattern::Ptr{Uint8},triggerWhen::int32,pretriggerSamples::uInt32)
-    ccall((:DAQmxCfgDigPatternRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},int32,uInt32),taskHandle,triggerSource,triggerPattern,triggerWhen,pretriggerSamples)
+function DAQmxCfgDigPatternRefTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerPattern::Ptr{UInt8},triggerWhen::int32,pretriggerSamples::uInt32)
+    ccall((:DAQmxCfgDigPatternRefTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},int32,uInt32),taskHandle,triggerSource,triggerPattern,triggerWhen,pretriggerSamples)
 end
 
 function DAQmxDisableAdvTrig(taskHandle::TaskHandle)
     ccall((:DAQmxDisableAdvTrig,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxCfgDigEdgeAdvTrig(taskHandle::TaskHandle,triggerSource::Ptr{Uint8},triggerEdge::int32)
-    ccall((:DAQmxCfgDigEdgeAdvTrig,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,triggerSource,triggerEdge)
+function DAQmxCfgDigEdgeAdvTrig(taskHandle::TaskHandle,triggerSource::Ptr{UInt8},triggerEdge::int32)
+    ccall((:DAQmxCfgDigEdgeAdvTrig,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,triggerSource,triggerEdge)
 end
 
 function DAQmxResetTrigAttribute(taskHandle::TaskHandle,attribute::int32)
@@ -538,20 +538,20 @@ function DAQmxReadRaw(taskHandle::TaskHandle,numSampsPerChan::int32,timeout::flo
     ccall((:DAQmxReadRaw,NIDAQmx),int32,(TaskHandle,int32,float64,Ptr{Void},uInt32,Ptr{int32},Ptr{int32},Ptr{bool32}),taskHandle,numSampsPerChan,timeout,readArray,arraySizeInBytes,sampsRead,numBytesPerSamp,reserved)
 end
 
-function DAQmxGetNthTaskReadChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{Uint8},bufferSize::int32)
-    ccall((:DAQmxGetNthTaskReadChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{Uint8},int32),taskHandle,index,buffer,bufferSize)
+function DAQmxGetNthTaskReadChannel(taskHandle::TaskHandle,index::uInt32,buffer::Ptr{UInt8},bufferSize::int32)
+    ccall((:DAQmxGetNthTaskReadChannel,NIDAQmx),int32,(TaskHandle,uInt32,Ptr{UInt8},int32),taskHandle,index,buffer,bufferSize)
 end
 
 function DAQmxResetReadAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetReadAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxConfigureLogging(taskHandle::TaskHandle,filePath::Ptr{Uint8},loggingMode::int32,groupName::Ptr{Uint8},operation::int32)
-    ccall((:DAQmxConfigureLogging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32,Ptr{Uint8},int32),taskHandle,filePath,loggingMode,groupName,operation)
+function DAQmxConfigureLogging(taskHandle::TaskHandle,filePath::Ptr{UInt8},loggingMode::int32,groupName::Ptr{UInt8},operation::int32)
+    ccall((:DAQmxConfigureLogging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32,Ptr{UInt8},int32),taskHandle,filePath,loggingMode,groupName,operation)
 end
 
-function DAQmxStartNewFile(taskHandle::TaskHandle,filePath::Ptr{Uint8})
-    ccall((:DAQmxStartNewFile,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,filePath)
+function DAQmxStartNewFile(taskHandle::TaskHandle,filePath::Ptr{UInt8})
+    ccall((:DAQmxStartNewFile,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,filePath)
 end
 
 function DAQmxWriteAnalogF64(taskHandle::TaskHandle,numSampsPerChan::int32,autoStart::bool32,timeout::float64,dataLayout::bool32,writeArray::Ptr{float64},sampsPerChanWritten::Ptr{int32},reserved::Ptr{bool32})
@@ -630,28 +630,28 @@ function DAQmxResetWriteAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetWriteAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxExportSignal(taskHandle::TaskHandle,signalID::int32,outputTerminal::Ptr{Uint8})
-    ccall((:DAQmxExportSignal,NIDAQmx),int32,(TaskHandle,int32,Ptr{Uint8}),taskHandle,signalID,outputTerminal)
+function DAQmxExportSignal(taskHandle::TaskHandle,signalID::int32,outputTerminal::Ptr{UInt8})
+    ccall((:DAQmxExportSignal,NIDAQmx),int32,(TaskHandle,int32,Ptr{UInt8}),taskHandle,signalID,outputTerminal)
 end
 
 function DAQmxResetExportedSignalAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetExportedSignalAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxCreateLinScale(name::Ptr{Uint8},slope::float64,yIntercept::float64,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreateLinScale,NIDAQmx),int32,(Ptr{Uint8},float64,float64,int32,Ptr{Uint8}),name,slope,yIntercept,preScaledUnits,scaledUnits)
+function DAQmxCreateLinScale(name::Ptr{UInt8},slope::float64,yIntercept::float64,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreateLinScale,NIDAQmx),int32,(Ptr{UInt8},float64,float64,int32,Ptr{UInt8}),name,slope,yIntercept,preScaledUnits,scaledUnits)
 end
 
-function DAQmxCreateMapScale(name::Ptr{Uint8},prescaledMin::float64,prescaledMax::float64,scaledMin::float64,scaledMax::float64,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreateMapScale,NIDAQmx),int32,(Ptr{Uint8},float64,float64,float64,float64,int32,Ptr{Uint8}),name,prescaledMin,prescaledMax,scaledMin,scaledMax,preScaledUnits,scaledUnits)
+function DAQmxCreateMapScale(name::Ptr{UInt8},prescaledMin::float64,prescaledMax::float64,scaledMin::float64,scaledMax::float64,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreateMapScale,NIDAQmx),int32,(Ptr{UInt8},float64,float64,float64,float64,int32,Ptr{UInt8}),name,prescaledMin,prescaledMax,scaledMin,scaledMax,preScaledUnits,scaledUnits)
 end
 
-function DAQmxCreatePolynomialScale(name::Ptr{Uint8},forwardCoeffs::Ptr{float64},numForwardCoeffsIn::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreatePolynomialScale,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{Uint8}),name,forwardCoeffs,numForwardCoeffsIn,reverseCoeffs,numReverseCoeffsIn,preScaledUnits,scaledUnits)
+function DAQmxCreatePolynomialScale(name::Ptr{UInt8},forwardCoeffs::Ptr{float64},numForwardCoeffsIn::uInt32,reverseCoeffs::Ptr{float64},numReverseCoeffsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreatePolynomialScale,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{UInt8}),name,forwardCoeffs,numForwardCoeffsIn,reverseCoeffs,numReverseCoeffsIn,preScaledUnits,scaledUnits)
 end
 
-function DAQmxCreateTableScale(name::Ptr{Uint8},prescaledVals::Ptr{float64},numPrescaledValsIn::uInt32,scaledVals::Ptr{float64},numScaledValsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{Uint8})
-    ccall((:DAQmxCreateTableScale,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{Uint8}),name,prescaledVals,numPrescaledValsIn,scaledVals,numScaledValsIn,preScaledUnits,scaledUnits)
+function DAQmxCreateTableScale(name::Ptr{UInt8},prescaledVals::Ptr{float64},numPrescaledValsIn::uInt32,scaledVals::Ptr{float64},numScaledValsIn::uInt32,preScaledUnits::int32,scaledUnits::Ptr{UInt8})
+    ccall((:DAQmxCreateTableScale,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32,Ptr{float64},uInt32,int32,Ptr{UInt8}),name,prescaledVals,numPrescaledValsIn,scaledVals,numScaledValsIn,preScaledUnits,scaledUnits)
 end
 
 function DAQmxCalculateReversePolyCoeff(forwardCoeffs::Ptr{float64},numForwardCoeffsIn::uInt32,minValX::float64,maxValX::float64,numPointsToCompute::int32,reversePolyOrder::int32,reverseCoeffs::Ptr{float64})
@@ -674,68 +674,68 @@ function DAQmxResetBufferAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetBufferAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxSwitchCreateScanList(scanList::Ptr{Uint8},taskHandle::Ptr{TaskHandle})
-    ccall((:DAQmxSwitchCreateScanList,NIDAQmx),int32,(Ptr{Uint8},Ptr{TaskHandle}),scanList,taskHandle)
+function DAQmxSwitchCreateScanList(scanList::Ptr{UInt8},taskHandle::Ptr{TaskHandle})
+    ccall((:DAQmxSwitchCreateScanList,NIDAQmx),int32,(Ptr{UInt8},Ptr{TaskHandle}),scanList,taskHandle)
 end
 
-function DAQmxSwitchConnect(switchChannel1::Ptr{Uint8},switchChannel2::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchConnect,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},bool32),switchChannel1,switchChannel2,waitForSettling)
+function DAQmxSwitchConnect(switchChannel1::Ptr{UInt8},switchChannel2::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchConnect,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},bool32),switchChannel1,switchChannel2,waitForSettling)
 end
 
-function DAQmxSwitchConnectMulti(connectionList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchConnectMulti,NIDAQmx),int32,(Ptr{Uint8},bool32),connectionList,waitForSettling)
+function DAQmxSwitchConnectMulti(connectionList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchConnectMulti,NIDAQmx),int32,(Ptr{UInt8},bool32),connectionList,waitForSettling)
 end
 
-function DAQmxSwitchDisconnect(switchChannel1::Ptr{Uint8},switchChannel2::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchDisconnect,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},bool32),switchChannel1,switchChannel2,waitForSettling)
+function DAQmxSwitchDisconnect(switchChannel1::Ptr{UInt8},switchChannel2::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchDisconnect,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},bool32),switchChannel1,switchChannel2,waitForSettling)
 end
 
-function DAQmxSwitchDisconnectMulti(connectionList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchDisconnectMulti,NIDAQmx),int32,(Ptr{Uint8},bool32),connectionList,waitForSettling)
+function DAQmxSwitchDisconnectMulti(connectionList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchDisconnectMulti,NIDAQmx),int32,(Ptr{UInt8},bool32),connectionList,waitForSettling)
 end
 
-function DAQmxSwitchDisconnectAll(deviceName::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchDisconnectAll,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,waitForSettling)
+function DAQmxSwitchDisconnectAll(deviceName::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchDisconnectAll,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,waitForSettling)
 end
 
-function DAQmxSwitchSetTopologyAndReset(deviceName::Ptr{Uint8},newTopology::Ptr{Uint8})
-    ccall((:DAQmxSwitchSetTopologyAndReset,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),deviceName,newTopology)
+function DAQmxSwitchSetTopologyAndReset(deviceName::Ptr{UInt8},newTopology::Ptr{UInt8})
+    ccall((:DAQmxSwitchSetTopologyAndReset,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),deviceName,newTopology)
 end
 
-function DAQmxSwitchFindPath(switchChannel1::Ptr{Uint8},switchChannel2::Ptr{Uint8},path::Ptr{Uint8},pathBufferSize::uInt32,pathStatus::Ptr{int32})
-    ccall((:DAQmxSwitchFindPath,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32,Ptr{int32}),switchChannel1,switchChannel2,path,pathBufferSize,pathStatus)
+function DAQmxSwitchFindPath(switchChannel1::Ptr{UInt8},switchChannel2::Ptr{UInt8},path::Ptr{UInt8},pathBufferSize::uInt32,pathStatus::Ptr{int32})
+    ccall((:DAQmxSwitchFindPath,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32,Ptr{int32}),switchChannel1,switchChannel2,path,pathBufferSize,pathStatus)
 end
 
-function DAQmxSwitchOpenRelays(relayList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchOpenRelays,NIDAQmx),int32,(Ptr{Uint8},bool32),relayList,waitForSettling)
+function DAQmxSwitchOpenRelays(relayList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchOpenRelays,NIDAQmx),int32,(Ptr{UInt8},bool32),relayList,waitForSettling)
 end
 
-function DAQmxSwitchCloseRelays(relayList::Ptr{Uint8},waitForSettling::bool32)
-    ccall((:DAQmxSwitchCloseRelays,NIDAQmx),int32,(Ptr{Uint8},bool32),relayList,waitForSettling)
+function DAQmxSwitchCloseRelays(relayList::Ptr{UInt8},waitForSettling::bool32)
+    ccall((:DAQmxSwitchCloseRelays,NIDAQmx),int32,(Ptr{UInt8},bool32),relayList,waitForSettling)
 end
 
-function DAQmxSwitchGetSingleRelayCount(relayName::Ptr{Uint8},count::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetSingleRelayCount,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),relayName,count)
+function DAQmxSwitchGetSingleRelayCount(relayName::Ptr{UInt8},count::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetSingleRelayCount,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),relayName,count)
 end
 
-function DAQmxSwitchGetMultiRelayCount(relayList::Ptr{Uint8},count::Ptr{uInt32},countArraySize::uInt32,numRelayCountsRead::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetMultiRelayCount,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,count,countArraySize,numRelayCountsRead)
+function DAQmxSwitchGetMultiRelayCount(relayList::Ptr{UInt8},count::Ptr{uInt32},countArraySize::uInt32,numRelayCountsRead::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetMultiRelayCount,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,count,countArraySize,numRelayCountsRead)
 end
 
-function DAQmxSwitchGetSingleRelayPos(relayName::Ptr{Uint8},relayPos::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetSingleRelayPos,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),relayName,relayPos)
+function DAQmxSwitchGetSingleRelayPos(relayName::Ptr{UInt8},relayPos::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetSingleRelayPos,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),relayName,relayPos)
 end
 
-function DAQmxSwitchGetMultiRelayPos(relayList::Ptr{Uint8},relayPos::Ptr{uInt32},relayPosArraySize::uInt32,numRelayPossRead::Ptr{uInt32})
-    ccall((:DAQmxSwitchGetMultiRelayPos,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,relayPos,relayPosArraySize,numRelayPossRead)
+function DAQmxSwitchGetMultiRelayPos(relayList::Ptr{UInt8},relayPos::Ptr{uInt32},relayPosArraySize::uInt32,numRelayPossRead::Ptr{uInt32})
+    ccall((:DAQmxSwitchGetMultiRelayPos,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32,Ptr{uInt32}),relayList,relayPos,relayPosArraySize,numRelayPossRead)
 end
 
-function DAQmxSwitchWaitForSettling(deviceName::Ptr{Uint8})
-    ccall((:DAQmxSwitchWaitForSettling,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxSwitchWaitForSettling(deviceName::Ptr{UInt8})
+    ccall((:DAQmxSwitchWaitForSettling,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxGetSwitchChanAttribute(switchChannelName::Ptr{Uint8},attribute::int32,value::Ptr{Void})
-    ccall((:DAQmxGetSwitchChanAttribute,NIDAQmx),int32,(Ptr{Uint8},int32,Ptr{Void}),switchChannelName,attribute,value)
+function DAQmxGetSwitchChanAttribute(switchChannelName::Ptr{UInt8},attribute::int32,value::Ptr{Void})
+    ccall((:DAQmxGetSwitchChanAttribute,NIDAQmx),int32,(Ptr{UInt8},int32,Ptr{Void}),switchChannelName,attribute,value)
 end
 
 function DAQmxGetSwitchScanAttribute(taskHandle::TaskHandle,attribute::int32,value::Ptr{Void})
@@ -746,68 +746,68 @@ function DAQmxResetSwitchScanAttribute(taskHandle::TaskHandle,attribute::int32)
     ccall((:DAQmxResetSwitchScanAttribute,NIDAQmx),int32,(TaskHandle,int32),taskHandle,attribute)
 end
 
-function DAQmxConnectTerms(sourceTerminal::Ptr{Uint8},destinationTerminal::Ptr{Uint8},signalModifiers::int32)
-    ccall((:DAQmxConnectTerms,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},int32),sourceTerminal,destinationTerminal,signalModifiers)
+function DAQmxConnectTerms(sourceTerminal::Ptr{UInt8},destinationTerminal::Ptr{UInt8},signalModifiers::int32)
+    ccall((:DAQmxConnectTerms,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},int32),sourceTerminal,destinationTerminal,signalModifiers)
 end
 
-function DAQmxDisconnectTerms(sourceTerminal::Ptr{Uint8},destinationTerminal::Ptr{Uint8})
-    ccall((:DAQmxDisconnectTerms,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),sourceTerminal,destinationTerminal)
+function DAQmxDisconnectTerms(sourceTerminal::Ptr{UInt8},destinationTerminal::Ptr{UInt8})
+    ccall((:DAQmxDisconnectTerms,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),sourceTerminal,destinationTerminal)
 end
 
-function DAQmxTristateOutputTerm(outputTerminal::Ptr{Uint8})
-    ccall((:DAQmxTristateOutputTerm,NIDAQmx),int32,(Ptr{Uint8},),outputTerminal)
+function DAQmxTristateOutputTerm(outputTerminal::Ptr{UInt8})
+    ccall((:DAQmxTristateOutputTerm,NIDAQmx),int32,(Ptr{UInt8},),outputTerminal)
 end
 
-function DAQmxResetDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxResetDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxResetDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxResetDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxSelfTestDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxSelfTestDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxSelfTestDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxSelfTestDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
 function DAQmxControlWatchdogTask(taskHandle::TaskHandle,action::int32)
     ccall((:DAQmxControlWatchdogTask,NIDAQmx),int32,(TaskHandle,int32),taskHandle,action)
 end
 
-function DAQmxResetWatchdogAttribute(taskHandle::TaskHandle,lines::Ptr{Uint8},attribute::int32)
-    ccall((:DAQmxResetWatchdogAttribute,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,attribute)
+function DAQmxResetWatchdogAttribute(taskHandle::TaskHandle,lines::Ptr{UInt8},attribute::int32)
+    ccall((:DAQmxResetWatchdogAttribute,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,attribute)
 end
 
-function DAQmxSelfCal(deviceName::Ptr{Uint8})
-    ccall((:DAQmxSelfCal,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxSelfCal(deviceName::Ptr{UInt8})
+    ccall((:DAQmxSelfCal,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxPerformBridgeOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxPerformBridgeOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxPerformBridgeOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxPerformBridgeOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxPerformBridgeOffsetNullingCalEx(taskHandle::TaskHandle,channel::Ptr{Uint8},skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformBridgeOffsetNullingCalEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,skipUnsupportedChannels)
+function DAQmxPerformBridgeOffsetNullingCalEx(taskHandle::TaskHandle,channel::Ptr{UInt8},skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformBridgeOffsetNullingCalEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,skipUnsupportedChannels)
 end
 
-function DAQmxPerformThrmcplLeadOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{Uint8},skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformThrmcplLeadOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,skipUnsupportedChannels)
+function DAQmxPerformThrmcplLeadOffsetNullingCal(taskHandle::TaskHandle,channel::Ptr{UInt8},skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformThrmcplLeadOffsetNullingCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,skipUnsupportedChannels)
 end
 
-function DAQmxPerformStrainShuntCal(taskHandle::TaskHandle,channel::Ptr{Uint8},shuntResistorValue::float64,shuntResistorLocation::int32,skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformStrainShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,skipUnsupportedChannels)
+function DAQmxPerformStrainShuntCal(taskHandle::TaskHandle,channel::Ptr{UInt8},shuntResistorValue::float64,shuntResistorLocation::int32,skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformStrainShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,skipUnsupportedChannels)
 end
 
-function DAQmxPerformBridgeShuntCal(taskHandle::TaskHandle,channel::Ptr{Uint8},shuntResistorValue::float64,shuntResistorLocation::int32,bridgeResistance::float64,skipUnsupportedChannels::bool32)
-    ccall((:DAQmxPerformBridgeShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64,int32,float64,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,bridgeResistance,skipUnsupportedChannels)
+function DAQmxPerformBridgeShuntCal(taskHandle::TaskHandle,channel::Ptr{UInt8},shuntResistorValue::float64,shuntResistorLocation::int32,bridgeResistance::float64,skipUnsupportedChannels::bool32)
+    ccall((:DAQmxPerformBridgeShuntCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64,int32,float64,bool32),taskHandle,channel,shuntResistorValue,shuntResistorLocation,bridgeResistance,skipUnsupportedChannels)
 end
 
-function DAQmxGetSelfCalLastDateAndTime(deviceName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetSelfCalLastDateAndTime,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
+function DAQmxGetSelfCalLastDateAndTime(deviceName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetSelfCalLastDateAndTime,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
 end
 
-function DAQmxGetExtCalLastDateAndTime(deviceName::Ptr{Uint8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
-    ccall((:DAQmxGetExtCalLastDateAndTime,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
+function DAQmxGetExtCalLastDateAndTime(deviceName::Ptr{UInt8},year::Ptr{uInt32},month::Ptr{uInt32},day::Ptr{uInt32},hour::Ptr{uInt32},minute::Ptr{uInt32})
+    ccall((:DAQmxGetExtCalLastDateAndTime,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32},Ptr{uInt32}),deviceName,year,month,day,hour,minute)
 end
 
-function DAQmxRestoreLastExtCalConst(deviceName::Ptr{Uint8})
-    ccall((:DAQmxRestoreLastExtCalConst,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxRestoreLastExtCalConst(deviceName::Ptr{UInt8})
+    ccall((:DAQmxRestoreLastExtCalConst,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
 function DAQmxESeriesCalAdjust(calHandle::CalHandle,referenceVoltage::float64)
@@ -834,20 +834,20 @@ function DAQmxXSeriesCalAdjust(calHandle::CalHandle,referenceVoltage::float64)
     ccall((:DAQmxXSeriesCalAdjust,NIDAQmx),int32,(CalHandle,float64),calHandle,referenceVoltage)
 end
 
-function DAQmxDeviceSupportsCal(deviceName::Ptr{Uint8},calSupported::Ptr{bool32})
-    ccall((:DAQmxDeviceSupportsCal,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,calSupported)
+function DAQmxDeviceSupportsCal(deviceName::Ptr{UInt8},calSupported::Ptr{bool32})
+    ccall((:DAQmxDeviceSupportsCal,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,calSupported)
 end
 
-function DAQmxInitExtCal(deviceName::Ptr{Uint8},password::Ptr{Uint8},calHandle::Ptr{CalHandle})
-    ccall((:DAQmxInitExtCal,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{CalHandle}),deviceName,password,calHandle)
+function DAQmxInitExtCal(deviceName::Ptr{UInt8},password::Ptr{UInt8},calHandle::Ptr{CalHandle})
+    ccall((:DAQmxInitExtCal,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{CalHandle}),deviceName,password,calHandle)
 end
 
 function DAQmxCloseExtCal(calHandle::CalHandle,action::int32)
     ccall((:DAQmxCloseExtCal,NIDAQmx),int32,(CalHandle,int32),calHandle,action)
 end
 
-function DAQmxChangeExtCalPassword(deviceName::Ptr{Uint8},password::Ptr{Uint8},newPassword::Ptr{Uint8})
-    ccall((:DAQmxChangeExtCalPassword,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8}),deviceName,password,newPassword)
+function DAQmxChangeExtCalPassword(deviceName::Ptr{UInt8},password::Ptr{UInt8},newPassword::Ptr{UInt8})
+    ccall((:DAQmxChangeExtCalPassword,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8}),deviceName,password,newPassword)
 end
 
 function DAQmxAdjustDSAAICal(calHandle::CalHandle,referenceVoltage::float64)
@@ -870,24 +870,24 @@ function DAQmxAdjustDSATimebaseCal(calHandle::CalHandle,referenceFrequency::floa
     ccall((:DAQmxAdjustDSATimebaseCal,NIDAQmx),int32,(CalHandle,float64),calHandle,referenceFrequency)
 end
 
-function DAQmxAdjust4204Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},lowPassFreq::float64,trackHoldEnabled::bool32,inputVal::float64)
-    ccall((:DAQmxAdjust4204Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,bool32,float64),calHandle,channelNames,lowPassFreq,trackHoldEnabled,inputVal)
+function DAQmxAdjust4204Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},lowPassFreq::float64,trackHoldEnabled::bool32,inputVal::float64)
+    ccall((:DAQmxAdjust4204Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,bool32,float64),calHandle,channelNames,lowPassFreq,trackHoldEnabled,inputVal)
 end
 
-function DAQmxAdjust4220Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},gain::float64,inputVal::float64)
-    ccall((:DAQmxAdjust4220Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,gain,inputVal)
+function DAQmxAdjust4220Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},gain::float64,inputVal::float64)
+    ccall((:DAQmxAdjust4220Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,gain,inputVal)
 end
 
-function DAQmxAdjust4224Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},gain::float64,inputVal::float64)
-    ccall((:DAQmxAdjust4224Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,gain,inputVal)
+function DAQmxAdjust4224Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},gain::float64,inputVal::float64)
+    ccall((:DAQmxAdjust4224Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,gain,inputVal)
 end
 
-function DAQmxAdjust4225Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},gain::float64,inputVal::float64)
-    ccall((:DAQmxAdjust4225Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,gain,inputVal)
+function DAQmxAdjust4225Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},gain::float64,inputVal::float64)
+    ccall((:DAQmxAdjust4225Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,gain,inputVal)
 end
 
-function DAQmxSetup433xCal(calHandle::CalHandle,channelNames::Ptr{Uint8},excitationVoltage::float64)
-    ccall((:DAQmxSetup433xCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,excitationVoltage)
+function DAQmxSetup433xCal(calHandle::CalHandle,channelNames::Ptr{UInt8},excitationVoltage::float64)
+    ccall((:DAQmxSetup433xCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,excitationVoltage)
 end
 
 function DAQmxAdjust433xCal(calHandle::CalHandle,refVoltage::float64,refExcitation::float64,shuntLocation::int32)
@@ -898,36 +898,36 @@ function DAQmxAdjust4300Cal(calHandle::CalHandle,refVoltage::float64)
     ccall((:DAQmxAdjust4300Cal,NIDAQmx),int32,(CalHandle,float64),calHandle,refVoltage)
 end
 
-function DAQmxAdjust4353Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},refVal::float64)
-    ccall((:DAQmxAdjust4353Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,refVal)
+function DAQmxAdjust4353Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},refVal::float64)
+    ccall((:DAQmxAdjust4353Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,refVal)
 end
 
-function DAQmxAdjust4357Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},refVals::Ptr{float64},numRefVals::int32)
-    ccall((:DAQmxAdjust4357Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},int32),calHandle,channelNames,refVals,numRefVals)
+function DAQmxAdjust4357Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},refVals::Ptr{float64},numRefVals::int32)
+    ccall((:DAQmxAdjust4357Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},int32),calHandle,channelNames,refVals,numRefVals)
 end
 
-function DAQmxSetup4322Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},outputType::int32,outputVal::float64)
-    ccall((:DAQmxSetup4322Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32,float64),calHandle,channelNames,outputType,outputVal)
+function DAQmxSetup4322Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},outputType::int32,outputVal::float64)
+    ccall((:DAQmxSetup4322Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32,float64),calHandle,channelNames,outputType,outputVal)
 end
 
-function DAQmxAdjust4322Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},refVal::float64)
-    ccall((:DAQmxAdjust4322Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,refVal)
+function DAQmxAdjust4322Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},refVal::float64)
+    ccall((:DAQmxAdjust4322Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,refVal)
 end
 
 function DAQmxGet4322CalAdjustPoints(calHandle::CalHandle,outputType::int32,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet4322CalAdjustPoints,NIDAQmx),int32,(CalHandle,int32,Ptr{float64},uInt32),calHandle,outputType,adjustmentPoints,bufferSize)
 end
 
-function DAQmxConnectSCExpressCalAccChans(calHandle::CalHandle,channelNames::Ptr{Uint8},connection::Ptr{Uint8})
-    ccall((:DAQmxConnectSCExpressCalAccChans,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{Uint8}),calHandle,channelNames,connection)
+function DAQmxConnectSCExpressCalAccChans(calHandle::CalHandle,channelNames::Ptr{UInt8},connection::Ptr{UInt8})
+    ccall((:DAQmxConnectSCExpressCalAccChans,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{UInt8}),calHandle,channelNames,connection)
 end
 
 function DAQmxDisconnectSCExpressCalAccChans(calHandle::CalHandle)
     ccall((:DAQmxDisconnectSCExpressCalAccChans,NIDAQmx),int32,(CalHandle,),calHandle)
 end
 
-function DAQmxGetPossibleSCExpressCalAccConnections(deviceName::Ptr{Uint8},channelNames::Ptr{Uint8},connections::Ptr{Uint8},connectionsBufferSize::uInt32)
-    ccall((:DAQmxGetPossibleSCExpressCalAccConnections,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,channelNames,connections,connectionsBufferSize)
+function DAQmxGetPossibleSCExpressCalAccConnections(deviceName::Ptr{UInt8},channelNames::Ptr{UInt8},connections::Ptr{UInt8},connectionsBufferSize::uInt32)
+    ccall((:DAQmxGetPossibleSCExpressCalAccConnections,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,channelNames,connections,connectionsBufferSize)
 end
 
 function DAQmxSetSCExpressCalAccBridgeOutput(calHandle::CalHandle,voltsPerVolt::float64)
@@ -942,20 +942,20 @@ function DAQmxCSeriesSetCalTemp(calHandle::CalHandle,temperature::float64)
     ccall((:DAQmxCSeriesSetCalTemp,NIDAQmx),int32,(CalHandle,float64),calHandle,temperature)
 end
 
-function DAQmxAdjust9201Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9201Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9201Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9201Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9203CalAdjustPoints(calHandle::CalHandle,rangeMin::float64,rangeMax::float64,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9203CalAdjustPoints,NIDAQmx),int32,(CalHandle,float64,float64,Ptr{float64},uInt32),calHandle,rangeMin,rangeMax,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9203GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,value::float64)
-    ccall((:DAQmxAdjust9203GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
+function DAQmxAdjust9203GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,value::float64)
+    ccall((:DAQmxAdjust9203GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
 end
 
-function DAQmxAdjust9203OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64)
-    ccall((:DAQmxAdjust9203OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelNames,rangeMin,rangeMax)
+function DAQmxAdjust9203OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64)
+    ccall((:DAQmxAdjust9203OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelNames,rangeMin,rangeMax)
 end
 
 function DAQmxAdjust9205Cal(calHandle::CalHandle,value::float64)
@@ -966,356 +966,356 @@ function DAQmxAdjust9206Cal(calHandle::CalHandle,value::float64)
     ccall((:DAQmxAdjust9206Cal,NIDAQmx),int32,(CalHandle,float64),calHandle,value)
 end
 
-function DAQmxGet9207CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{Uint8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
-    ccall((:DAQmxGet9207CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
+function DAQmxGet9207CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{UInt8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
+    ccall((:DAQmxGet9207CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9207GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9207GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9207GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9207GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9207OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAdjust9207OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelNames)
+function DAQmxAdjust9207OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAdjust9207OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelNames)
 end
 
 function DAQmxGet9208CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9208CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9208GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9208GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9208GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9208GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9208OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAdjust9208OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelNames)
+function DAQmxAdjust9208OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAdjust9208OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelNames)
 end
 
-function DAQmxAdjust9211Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9211Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9211Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9211Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9213CalAdjustPoints(calHandle::CalHandle,rangeMin::float64,rangeMax::float64,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9213CalAdjustPoints,NIDAQmx),int32,(CalHandle,float64,float64,Ptr{float64},uInt32),calHandle,rangeMin,rangeMax,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9213Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,value::float64)
-    ccall((:DAQmxAdjust9213Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
+function DAQmxAdjust9213Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,value::float64)
+    ccall((:DAQmxAdjust9213Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,float64),calHandle,channelNames,rangeMin,rangeMax,value)
 end
 
-function DAQmxGet9214CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{Uint8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
-    ccall((:DAQmxGet9214CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{Uint8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
+function DAQmxGet9214CalAdjustPoints(calHandle::CalHandle,channelNames::Ptr{UInt8},adjustmentPoints::Ptr{float64},bufferSize::uInt32)
+    ccall((:DAQmxGet9214CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{UInt8},Ptr{float64},uInt32),calHandle,channelNames,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9214Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9214Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9214Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9214Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9215CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9215CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9215Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9215Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9215Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9215Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9217CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9217CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9217Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9217Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9217Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9217Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxSetup9219Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},rangeMin::float64,rangeMax::float64,measType::int32,bridgeConfig::int32)
-    ccall((:DAQmxSetup9219Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64,int32,int32),calHandle,channelNames,rangeMin,rangeMax,measType,bridgeConfig)
+function DAQmxSetup9219Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},rangeMin::float64,rangeMax::float64,measType::int32,bridgeConfig::int32)
+    ccall((:DAQmxSetup9219Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64,int32,int32),calHandle,channelNames,rangeMin,rangeMax,measType,bridgeConfig)
 end
 
 function DAQmxGet9219CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9219CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9219Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9219Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9219Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9219Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9220CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9220CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9220Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9220Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9220Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9220Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9221CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9221CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9221Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9221Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9221Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9221Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9222CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9222CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9222Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9222Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9222Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9222Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9223CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9223CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9223Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9223Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9223Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9223Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9225CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9225CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9225Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9225Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9225Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9225Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9227CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9227CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9227Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9227Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9227Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9227Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9229CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9229CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9229Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9229Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9229Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9229Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9232CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9232CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9232Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9232Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9232Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9232Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9234CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9234CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9234GainCal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9234GainCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9234GainCal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9234GainCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9234OffsetCal(calHandle::CalHandle,channelNames::Ptr{Uint8})
-    ccall((:DAQmxAdjust9234OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelNames)
+function DAQmxAdjust9234OffsetCal(calHandle::CalHandle,channelNames::Ptr{UInt8})
+    ccall((:DAQmxAdjust9234OffsetCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelNames)
 end
 
 function DAQmxGet9239CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{float64},bufferSize::uInt32)
     ccall((:DAQmxGet9239CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{float64},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxAdjust9239Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9239Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9239Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9239Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9263CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9263CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9263Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9263Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9263Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9263Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9263Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9263Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9263Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9263Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9264CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9264CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9264Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9264Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9264Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9264Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9264Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9264Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9264Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9264Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9265CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9265CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9265Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9265Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9265Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9265Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9265Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9265Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9265Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9265Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
 function DAQmxGet9269CalAdjustPoints(calHandle::CalHandle,adjustmentPoints::Ptr{int32},bufferSize::uInt32)
     ccall((:DAQmxGet9269CalAdjustPoints,NIDAQmx),int32,(CalHandle,Ptr{int32},uInt32),calHandle,adjustmentPoints,bufferSize)
 end
 
-function DAQmxSetup9269Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::int32)
-    ccall((:DAQmxSetup9269Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32),calHandle,channelNames,value)
+function DAQmxSetup9269Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::int32)
+    ccall((:DAQmxSetup9269Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32),calHandle,channelNames,value)
 end
 
-function DAQmxAdjust9269Cal(calHandle::CalHandle,channelNames::Ptr{Uint8},value::float64)
-    ccall((:DAQmxAdjust9269Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelNames,value)
+function DAQmxAdjust9269Cal(calHandle::CalHandle,channelNames::Ptr{UInt8},value::float64)
+    ccall((:DAQmxAdjust9269Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelNames,value)
 end
 
-function DAQmxSetup1102Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1102Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1102Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1102Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1102Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1102Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1104Cal(calHandle::CalHandle,channelName::Ptr{Uint8})
-    ccall((:DAQmxSetup1104Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelName)
+function DAQmxSetup1104Cal(calHandle::CalHandle,channelName::Ptr{UInt8})
+    ccall((:DAQmxSetup1104Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelName)
 end
 
 function DAQmxAdjust1104Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1104Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1112Cal(calHandle::CalHandle,channelName::Ptr{Uint8})
-    ccall((:DAQmxSetup1112Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelName)
+function DAQmxSetup1112Cal(calHandle::CalHandle,channelName::Ptr{UInt8})
+    ccall((:DAQmxSetup1112Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelName)
 end
 
 function DAQmxAdjust1112Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1112Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1122Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1122Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1122Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1122Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1122Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1122Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1124Cal(calHandle::CalHandle,channelName::Ptr{Uint8},range::int32,dacValue::uInt32)
-    ccall((:DAQmxSetup1124Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},int32,uInt32),calHandle,channelName,range,dacValue)
+function DAQmxSetup1124Cal(calHandle::CalHandle,channelName::Ptr{UInt8},range::int32,dacValue::uInt32)
+    ccall((:DAQmxSetup1124Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},int32,uInt32),calHandle,channelName,range,dacValue)
 end
 
 function DAQmxAdjust1124Cal(calHandle::CalHandle,measOutput::float64)
     ccall((:DAQmxAdjust1124Cal,NIDAQmx),int32,(CalHandle,float64),calHandle,measOutput)
 end
 
-function DAQmxSetup1125Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1125Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1125Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1125Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1125Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1125Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1126Cal(calHandle::CalHandle,channelName::Ptr{Uint8},upperFreqLimit::float64)
-    ccall((:DAQmxSetup1126Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,upperFreqLimit)
+function DAQmxSetup1126Cal(calHandle::CalHandle,channelName::Ptr{UInt8},upperFreqLimit::float64)
+    ccall((:DAQmxSetup1126Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,upperFreqLimit)
 end
 
 function DAQmxAdjust1126Cal(calHandle::CalHandle,refFreq::float64,measOutput::float64)
     ccall((:DAQmxAdjust1126Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refFreq,measOutput)
 end
 
-function DAQmxSetup1141Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1141Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1141Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1141Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1141Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1141Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1142Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1142Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1142Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1142Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1142Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1142Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1143Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1143Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1143Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1143Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1143Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1143Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1502Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1502Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1502Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1502Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1502Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1502Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1503Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1503Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1503Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1503Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1503Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1503Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxAdjust1503CurrentCal(calHandle::CalHandle,channelName::Ptr{Uint8},measCurrent::float64)
-    ccall((:DAQmxAdjust1503CurrentCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,measCurrent)
+function DAQmxAdjust1503CurrentCal(calHandle::CalHandle,channelName::Ptr{UInt8},measCurrent::float64)
+    ccall((:DAQmxAdjust1503CurrentCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,measCurrent)
 end
 
-function DAQmxSetup1520Cal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup1520Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup1520Cal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup1520Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust1520Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1520Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1521Cal(calHandle::CalHandle,channelName::Ptr{Uint8})
-    ccall((:DAQmxSetup1521Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8}),calHandle,channelName)
+function DAQmxSetup1521Cal(calHandle::CalHandle,channelName::Ptr{UInt8})
+    ccall((:DAQmxSetup1521Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8}),calHandle,channelName)
 end
 
 function DAQmxAdjust1521Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust1521Cal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup153xCal(calHandle::CalHandle,channelName::Ptr{Uint8},gain::float64)
-    ccall((:DAQmxSetup153xCal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64),calHandle,channelName,gain)
+function DAQmxSetup153xCal(calHandle::CalHandle,channelName::Ptr{UInt8},gain::float64)
+    ccall((:DAQmxSetup153xCal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64),calHandle,channelName,gain)
 end
 
 function DAQmxAdjust153xCal(calHandle::CalHandle,refVoltage::float64,measOutput::float64)
     ccall((:DAQmxAdjust153xCal,NIDAQmx),int32,(CalHandle,float64,float64),calHandle,refVoltage,measOutput)
 end
 
-function DAQmxSetup1540Cal(calHandle::CalHandle,channelName::Ptr{Uint8},excitationVoltage::float64,excitationFreq::float64)
-    ccall((:DAQmxSetup1540Cal,NIDAQmx),int32,(CalHandle,Ptr{Uint8},float64,float64),calHandle,channelName,excitationVoltage,excitationFreq)
+function DAQmxSetup1540Cal(calHandle::CalHandle,channelName::Ptr{UInt8},excitationVoltage::float64,excitationFreq::float64)
+    ccall((:DAQmxSetup1540Cal,NIDAQmx),int32,(CalHandle,Ptr{UInt8},float64,float64),calHandle,channelName,excitationVoltage,excitationFreq)
 end
 
 function DAQmxAdjust1540Cal(calHandle::CalHandle,refVoltage::float64,measOutput::float64,inputCalSource::int32)
     ccall((:DAQmxAdjust1540Cal,NIDAQmx),int32,(CalHandle,float64,float64,int32),calHandle,refVoltage,measOutput,inputCalSource)
 end
 
-function DAQmxConfigureTEDS(physicalChannel::Ptr{Uint8},filePath::Ptr{Uint8})
-    ccall((:DAQmxConfigureTEDS,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),physicalChannel,filePath)
+function DAQmxConfigureTEDS(physicalChannel::Ptr{UInt8},filePath::Ptr{UInt8})
+    ccall((:DAQmxConfigureTEDS,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),physicalChannel,filePath)
 end
 
-function DAQmxClearTEDS(physicalChannel::Ptr{Uint8})
-    ccall((:DAQmxClearTEDS,NIDAQmx),int32,(Ptr{Uint8},),physicalChannel)
+function DAQmxClearTEDS(physicalChannel::Ptr{UInt8})
+    ccall((:DAQmxClearTEDS,NIDAQmx),int32,(Ptr{UInt8},),physicalChannel)
 end
 
-function DAQmxWriteToTEDSFromArray(physicalChannel::Ptr{Uint8},bitStream::Ptr{uInt8},arraySize::uInt32,basicTEDSOptions::int32)
-    ccall((:DAQmxWriteToTEDSFromArray,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt8},uInt32,int32),physicalChannel,bitStream,arraySize,basicTEDSOptions)
+function DAQmxWriteToTEDSFromArray(physicalChannel::Ptr{UInt8},bitStream::Ptr{uInt8},arraySize::uInt32,basicTEDSOptions::int32)
+    ccall((:DAQmxWriteToTEDSFromArray,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt8},uInt32,int32),physicalChannel,bitStream,arraySize,basicTEDSOptions)
 end
 
-function DAQmxWriteToTEDSFromFile(physicalChannel::Ptr{Uint8},filePath::Ptr{Uint8},basicTEDSOptions::int32)
-    ccall((:DAQmxWriteToTEDSFromFile,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},int32),physicalChannel,filePath,basicTEDSOptions)
+function DAQmxWriteToTEDSFromFile(physicalChannel::Ptr{UInt8},filePath::Ptr{UInt8},basicTEDSOptions::int32)
+    ccall((:DAQmxWriteToTEDSFromFile,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},int32),physicalChannel,filePath,basicTEDSOptions)
 end
 
 function DAQmxWaitForNextSampleClock(taskHandle::TaskHandle,timeout::float64,isLate::Ptr{bool32})
@@ -1330,84 +1330,84 @@ function DAQmxIsReadOrWriteLate(errorCode::int32)
     ccall((:DAQmxIsReadOrWriteLate,NIDAQmx),bool32,(int32,),errorCode)
 end
 
-function DAQmxSaveTask(taskHandle::TaskHandle,saveAs::Ptr{Uint8},author::Ptr{Uint8},options::uInt32)
-    ccall((:DAQmxSaveTask,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,saveAs,author,options)
+function DAQmxSaveTask(taskHandle::TaskHandle,saveAs::Ptr{UInt8},author::Ptr{UInt8},options::uInt32)
+    ccall((:DAQmxSaveTask,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,saveAs,author,options)
 end
 
-function DAQmxSaveGlobalChan(taskHandle::TaskHandle,channelName::Ptr{Uint8},saveAs::Ptr{Uint8},author::Ptr{Uint8},options::uInt32)
-    ccall((:DAQmxSaveGlobalChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channelName,saveAs,author,options)
+function DAQmxSaveGlobalChan(taskHandle::TaskHandle,channelName::Ptr{UInt8},saveAs::Ptr{UInt8},author::Ptr{UInt8},options::uInt32)
+    ccall((:DAQmxSaveGlobalChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channelName,saveAs,author,options)
 end
 
-function DAQmxSaveScale(scaleName::Ptr{Uint8},saveAs::Ptr{Uint8},author::Ptr{Uint8},options::uInt32)
-    ccall((:DAQmxSaveScale,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,saveAs,author,options)
+function DAQmxSaveScale(scaleName::Ptr{UInt8},saveAs::Ptr{UInt8},author::Ptr{UInt8},options::uInt32)
+    ccall((:DAQmxSaveScale,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,saveAs,author,options)
 end
 
-function DAQmxDeleteSavedTask(taskName::Ptr{Uint8})
-    ccall((:DAQmxDeleteSavedTask,NIDAQmx),int32,(Ptr{Uint8},),taskName)
+function DAQmxDeleteSavedTask(taskName::Ptr{UInt8})
+    ccall((:DAQmxDeleteSavedTask,NIDAQmx),int32,(Ptr{UInt8},),taskName)
 end
 
-function DAQmxDeleteSavedGlobalChan(channelName::Ptr{Uint8})
-    ccall((:DAQmxDeleteSavedGlobalChan,NIDAQmx),int32,(Ptr{Uint8},),channelName)
+function DAQmxDeleteSavedGlobalChan(channelName::Ptr{UInt8})
+    ccall((:DAQmxDeleteSavedGlobalChan,NIDAQmx),int32,(Ptr{UInt8},),channelName)
 end
 
-function DAQmxDeleteSavedScale(scaleName::Ptr{Uint8})
-    ccall((:DAQmxDeleteSavedScale,NIDAQmx),int32,(Ptr{Uint8},),scaleName)
+function DAQmxDeleteSavedScale(scaleName::Ptr{UInt8})
+    ccall((:DAQmxDeleteSavedScale,NIDAQmx),int32,(Ptr{UInt8},),scaleName)
 end
 
-function DAQmxSetDigitalLogicFamilyPowerUpState(deviceName::Ptr{Uint8},logicFamily::int32)
-    ccall((:DAQmxSetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{Uint8},int32),deviceName,logicFamily)
+function DAQmxSetDigitalLogicFamilyPowerUpState(deviceName::Ptr{UInt8},logicFamily::int32)
+    ccall((:DAQmxSetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{UInt8},int32),deviceName,logicFamily)
 end
 
-function DAQmxGetDigitalLogicFamilyPowerUpState(deviceName::Ptr{Uint8},logicFamily::Ptr{int32})
-    ccall((:DAQmxGetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),deviceName,logicFamily)
+function DAQmxGetDigitalLogicFamilyPowerUpState(deviceName::Ptr{UInt8},logicFamily::Ptr{int32})
+    ccall((:DAQmxGetDigitalLogicFamilyPowerUpState,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),deviceName,logicFamily)
 end
 
-function DAQmxAddNetworkDevice(IPAddress::Ptr{Uint8},deviceName::Ptr{Uint8},attemptReservation::bool32,timeout::float64,deviceNameOut::Ptr{Uint8},deviceNameOutBufferSize::uInt32)
-    ccall((:DAQmxAddNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},bool32,float64,Ptr{Uint8},uInt32),IPAddress,deviceName,attemptReservation,timeout,deviceNameOut,deviceNameOutBufferSize)
+function DAQmxAddNetworkDevice(IPAddress::Ptr{UInt8},deviceName::Ptr{UInt8},attemptReservation::bool32,timeout::float64,deviceNameOut::Ptr{UInt8},deviceNameOutBufferSize::uInt32)
+    ccall((:DAQmxAddNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},bool32,float64,Ptr{UInt8},uInt32),IPAddress,deviceName,attemptReservation,timeout,deviceNameOut,deviceNameOutBufferSize)
 end
 
-function DAQmxDeleteNetworkDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxDeleteNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxDeleteNetworkDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxDeleteNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxReserveNetworkDevice(deviceName::Ptr{Uint8},overrideReservation::bool32)
-    ccall((:DAQmxReserveNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,overrideReservation)
+function DAQmxReserveNetworkDevice(deviceName::Ptr{UInt8},overrideReservation::bool32)
+    ccall((:DAQmxReserveNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,overrideReservation)
 end
 
-function DAQmxUnreserveNetworkDevice(deviceName::Ptr{Uint8})
-    ccall((:DAQmxUnreserveNetworkDevice,NIDAQmx),int32,(Ptr{Uint8},),deviceName)
+function DAQmxUnreserveNetworkDevice(deviceName::Ptr{UInt8})
+    ccall((:DAQmxUnreserveNetworkDevice,NIDAQmx),int32,(Ptr{UInt8},),deviceName)
 end
 
-function DAQmxAutoConfigureCDAQSyncConnections(chassisDevicesPorts::Ptr{Uint8},timeout::float64)
-    ccall((:DAQmxAutoConfigureCDAQSyncConnections,NIDAQmx),int32,(Ptr{Uint8},float64),chassisDevicesPorts,timeout)
+function DAQmxAutoConfigureCDAQSyncConnections(chassisDevicesPorts::Ptr{UInt8},timeout::float64)
+    ccall((:DAQmxAutoConfigureCDAQSyncConnections,NIDAQmx),int32,(Ptr{UInt8},float64),chassisDevicesPorts,timeout)
 end
 
-function DAQmxGetAutoConfiguredCDAQSyncConnections(portList::Ptr{Uint8},portListSize::uInt32)
-    ccall((:DAQmxGetAutoConfiguredCDAQSyncConnections,NIDAQmx),int32,(Ptr{Uint8},uInt32),portList,portListSize)
+function DAQmxGetAutoConfiguredCDAQSyncConnections(portList::Ptr{UInt8},portListSize::uInt32)
+    ccall((:DAQmxGetAutoConfiguredCDAQSyncConnections,NIDAQmx),int32,(Ptr{UInt8},uInt32),portList,portListSize)
 end
 
-function DAQmxAreConfiguredCDAQSyncPortsDisconnected(chassisDevicesPorts::Ptr{Uint8},timeout::float64,disconnectedPortsExist::Ptr{bool32})
-    ccall((:DAQmxAreConfiguredCDAQSyncPortsDisconnected,NIDAQmx),int32,(Ptr{Uint8},float64,Ptr{bool32}),chassisDevicesPorts,timeout,disconnectedPortsExist)
+function DAQmxAreConfiguredCDAQSyncPortsDisconnected(chassisDevicesPorts::Ptr{UInt8},timeout::float64,disconnectedPortsExist::Ptr{bool32})
+    ccall((:DAQmxAreConfiguredCDAQSyncPortsDisconnected,NIDAQmx),int32,(Ptr{UInt8},float64,Ptr{bool32}),chassisDevicesPorts,timeout,disconnectedPortsExist)
 end
 
-function DAQmxGetDisconnectedCDAQSyncPorts(portList::Ptr{Uint8},portListSize::uInt32)
-    ccall((:DAQmxGetDisconnectedCDAQSyncPorts,NIDAQmx),int32,(Ptr{Uint8},uInt32),portList,portListSize)
+function DAQmxGetDisconnectedCDAQSyncPorts(portList::Ptr{UInt8},portListSize::uInt32)
+    ccall((:DAQmxGetDisconnectedCDAQSyncPorts,NIDAQmx),int32,(Ptr{UInt8},uInt32),portList,portListSize)
 end
 
-function DAQmxAddCDAQSyncConnection(portList::Ptr{Uint8})
-    ccall((:DAQmxAddCDAQSyncConnection,NIDAQmx),int32,(Ptr{Uint8},),portList)
+function DAQmxAddCDAQSyncConnection(portList::Ptr{UInt8})
+    ccall((:DAQmxAddCDAQSyncConnection,NIDAQmx),int32,(Ptr{UInt8},),portList)
 end
 
-function DAQmxRemoveCDAQSyncConnection(portList::Ptr{Uint8})
-    ccall((:DAQmxRemoveCDAQSyncConnection,NIDAQmx),int32,(Ptr{Uint8},),portList)
+function DAQmxRemoveCDAQSyncConnection(portList::Ptr{UInt8})
+    ccall((:DAQmxRemoveCDAQSyncConnection,NIDAQmx),int32,(Ptr{UInt8},),portList)
 end
 
-function DAQmxGetErrorString(errorCode::int32,errorString::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetErrorString,NIDAQmx),int32,(int32,Ptr{Uint8},uInt32),errorCode,errorString,bufferSize)
+function DAQmxGetErrorString(errorCode::int32,errorString::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetErrorString,NIDAQmx),int32,(int32,Ptr{UInt8},uInt32),errorCode,errorString,bufferSize)
 end
 
-function DAQmxGetExtendedErrorInfo(errorString::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExtendedErrorInfo,NIDAQmx),int32,(Ptr{Uint8},uInt32),errorString,bufferSize)
+function DAQmxGetExtendedErrorInfo(errorString::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExtendedErrorInfo,NIDAQmx),int32,(Ptr{UInt8},uInt32),errorString,bufferSize)
 end
 
 function DAQmxGetBufInputBufSize(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -1450,4940 +1450,4940 @@ function DAQmxResetBufOutputOnbrdBufSize(taskHandle::TaskHandle)
     ccall((:DAQmxResetBufOutputOnbrdBufSize,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSelfCalSupported(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSelfCalSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSelfCalSupported(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSelfCalSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxGetSelfCalLastTemp(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSelfCalLastTemp,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetSelfCalLastTemp(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSelfCalLastTemp,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxGetExtCalRecommendedInterval(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetExtCalRecommendedInterval,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetExtCalRecommendedInterval(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetExtCalRecommendedInterval,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetExtCalLastTemp(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetExtCalLastTemp,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetExtCalLastTemp(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetExtCalLastTemp,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxGetCalUserDefinedInfo(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetCalUserDefinedInfo(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxSetCalUserDefinedInfo(deviceName::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),deviceName,data)
+function DAQmxSetCalUserDefinedInfo(deviceName::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCalUserDefinedInfo,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),deviceName,data)
 end
 
-function DAQmxGetCalUserDefinedInfoMaxSize(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCalUserDefinedInfoMaxSize,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetCalUserDefinedInfoMaxSize(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCalUserDefinedInfoMaxSize,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetCalDevTemp(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCalDevTemp,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetCalDevTemp(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCalDevTemp,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxGetCalAccConnectionCount(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCalAccConnectionCount,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetCalAccConnectionCount(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCalAccConnectionCount,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxSetCalAccConnectionCount(deviceName::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCalAccConnectionCount,NIDAQmx),int32,(Ptr{Uint8},uInt32),deviceName,data)
+function DAQmxSetCalAccConnectionCount(deviceName::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCalAccConnectionCount,NIDAQmx),int32,(Ptr{UInt8},uInt32),deviceName,data)
 end
 
-function DAQmxGetCalRecommendedAccConnectionCountLimit(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCalRecommendedAccConnectionCountLimit,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetCalRecommendedAccConnectionCountLimit(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCalRecommendedAccConnectionCountLimit,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetAIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMax(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMax(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMin(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMin(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVoltagedBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVoltagedBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVoltageACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVoltageACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAITempUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAITempUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAITempUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAITempUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAITempUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAITempUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAITempUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplCJCSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIThrmcplCJCSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplCJCSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIThrmcplCJCSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplCJCVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplCJCVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplCJCChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIThrmcplCJCChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIThrmcplCJCChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIThrmcplCJCChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxGetAIRTDType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRTDType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRTDType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDR0(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDR0,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDA(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDA(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDB(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDB(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRTDC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRTDC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRTDC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRTDC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRTDC(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRTDC(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRTDC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrA(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrA,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrB(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrB,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrC(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmstrR1(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmstrR1,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentACRMSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentACRMSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGageForceReadFromChan(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGageForceReadFromChan,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGageGageFactor(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGageGageFactor,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGagePoissonRatio(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGagePoissonRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIStrainGageCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIStrainGageCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRosetteStrainGageRosetteType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRosetteStrainGageRosetteType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRosetteStrainGageRosetteType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRosetteStrainGageRosetteType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRosetteStrainGageOrientation(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRosetteStrainGageOrientation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRosetteStrainGageStrainChans(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIRosetteStrainGageStrainChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIRosetteStrainGageStrainChans(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIRosetteStrainGageStrainChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxGetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRosetteStrainGageRosetteMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRosetteStrainGageRosetteMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIResistanceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIResistanceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFreqThreshVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFreqThreshVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIFreqHyst(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIFreqHyst,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRVDTUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRVDTUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRVDTSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRVDTSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRVDTSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRVDTSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEddyCurrentProxProbeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEddyCurrentProxProbeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEddyCurrentProxProbeSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEddyCurrentProxProbeSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEddyCurrentProxProbeSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISoundPressureMaxSoundPressureLvl(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISoundPressureMaxSoundPressureLvl,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISoundPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISoundPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISoundPressuredBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISoundPressuredBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMicrophoneSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMicrophoneSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAccelUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAccelUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAcceldBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAcceldBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAccelSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAccelSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAccelSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAccelSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityIEPESensordBRef(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityIEPESensordBRef,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIVelocityIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIVelocityIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceIEPESensorSensitivity(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceIEPESensorSensitivity,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIForceIEPESensorSensitivityUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIForceIEPESensorSensitivityUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIPressureUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIPressureUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAITorqueUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAITorqueUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeElectricalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeElectricalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgePhysicalUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgePhysicalUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinFirstElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinFirstElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinFirstPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinSecondElectricalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinSecondElectricalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTwoPointLinSecondPhysicalVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTableElectricalVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTableElectricalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeTablePhysicalVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeTablePhysicalVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgePolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgePolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgePolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgePolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIIsTEDS(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIIsTEDS,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIIsTEDS(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIIsTEDS,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAITEDSUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAITEDSUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAITEDSUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAITEDSUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxGetAICoupling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICoupling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICoupling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICoupling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICoupling(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICoupling(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICoupling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAITermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAITermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAITermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAITermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAITermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAITermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAITermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIInputSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIInputSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIResistanceCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIResistanceCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILeadWireResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILeadWireResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeNomResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeNomResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeInitialVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeInitialVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeInitialRatio(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeInitialRatio,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalSelect(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalSelect,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalGainAdjust(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalGainAdjust,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalShuntCalAResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeShuntCalShuntCalAActualResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeShuntCalShuntCalAActualResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeBalanceCoarsePot(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeBalanceCoarsePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIBridgeBalanceFinePot(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIBridgeBalanceFinePot,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentShuntLoc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentShuntLoc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAICurrentShuntResistance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAICurrentShuntResistance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitUseForScaling(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitUseForScaling,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitUseMultiplexed(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitUseMultiplexed,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitActualVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitActualVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitDCorAC(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitDCorAC,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIExcitVoltageOrCurrent(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIExcitVoltageOrCurrent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIACExcitFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIACExcitFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIACExcitSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIACExcitSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIACExcitWireMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIACExcitWireMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIOpenThrmcplDetectEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIOpenThrmcplDetectEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIThrmcplLeadOffsetVoltage(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIThrmcplLeadOffsetVoltage,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAtten(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAtten(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIProbeAtten(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIProbeAtten,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassCutoffFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassCutoffFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapClkSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapExtClkFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapExtClkFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapExtClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapExtClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILowpassSwitchCapOutClkDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILowpassSwitchCapOutClkDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRemoveFilterDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRemoveFilterDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAveragingWinSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAveragingWinSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIResolution(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIResolution,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIResolution(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIResolution,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRawSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIRawSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIRawSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIRawSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIRawSampJustification(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRawSampJustification,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRawSampJustification(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRawSampJustification,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIADCTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIADCTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIADCCustomTimingMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIADCCustomTimingMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDitherEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDitherEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalHasValidCalInfo(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIChanCalHasValidCalInfo,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalHasValidCalInfo(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIChanCalHasValidCalInfo,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalEnableCal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalEnableCal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalApplyCalIfExp(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalApplyCalIfExp,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalScaleType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalScaleType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalTablePreScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalTablePreScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalTableScaledVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalTableScaledVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalPolyForwardCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalPolyForwardCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalPolyReverseCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalPolyReverseCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalOperatorName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalOperatorName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalDesc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalDesc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalVerifRefVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalVerifRefVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxSetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxSetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxResetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIChanCalVerifAcqVals(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIChanCalVerifAcqVals,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDCOffset(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDCOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAIGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAIGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAIGain(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIGain(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAISampAndHoldEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAISampAndHoldEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIAutoZeroMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIAutoZeroMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIDataXferCustomThreshold(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIDataXferCustomThreshold,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIRawDataCompressionType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIRawDataCompressionType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAILossyLSBRemovalCompressedSampSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAILossyLSBRemovalCompressedSampSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAIDevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAIDevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAIDevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAIDevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxGetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAIEnhancedAliasRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAIEnhancedAliasRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOMax(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOMax(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOMin(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOMin(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOCustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOCustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOOutputType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOOutputType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOVoltageUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOVoltageUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOVoltageCurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOVoltageCurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOCurrentUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOCurrentUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenAmplitude(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenAmplitude,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenOffset(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenOffset,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenSquareDutyCycle(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenSquareDutyCycle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenModulationType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenModulationType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOFuncGenFMDeviation(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOFuncGenFMDeviation,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOOutputImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOOutputImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOLoadImpedance(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOLoadImpedance,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOIdleOutputBehavior(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOIdleOutputBehavior,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOTermCfg(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOTermCfg,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOResolutionUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOResolutionUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOResolution(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOResolution,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOResolution(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOResolution,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxGetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRngHigh(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRngHigh,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRngLow(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRngLow,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefAllowConnToGnd(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefAllowConnToGnd,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACRefVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACRefVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACOffsetSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACOffsetSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACOffsetExtSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACOffsetExtSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODACOffsetVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODACOffsetVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOReglitchEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOReglitchEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetAOGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOGain(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetAOGain(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetAOGain(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOGain(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOGain,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetAODevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetAODevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
+function DAQmxGetAODevScalingCoeff(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetAODevScalingCoeff,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64},uInt32),taskHandle,channel,data,arraySizeInElements)
 end
 
-function DAQmxGetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetAOEnhancedImageRejectionEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetAOEnhancedImageRejectionEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDINumLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDINumLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDINumLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDINumLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrEnableBusMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrEnableBusMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDITristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDITristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDITristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDITristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDITristate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDITristate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDITristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDILogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDILogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDIAcquireOn(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDIAcquireOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOutputDriveType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOutputDriveType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOInvertLines(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOInvertLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDONumLines(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDONumLines,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDONumLines(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDONumLines,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetDOTristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOTristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOTristate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOTristate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOTristate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOTristate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOTristate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLineStatesStartState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLineStatesStartState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLineStatesPausedState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLineStatesPausedState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLineStatesDoneState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLineStatesDoneState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOLogicFamily(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOLogicFamily,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOvercurrentLimit(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOvercurrentLimit,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOvercurrentAutoReenable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOvercurrentAutoReenable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOOvercurrentReenablePeriod(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOOvercurrentReenablePeriod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetDOGenerateOn(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetDOGenerateOn,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIMax(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIMax(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIMax(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIMax(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIMax,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIMin(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIMin(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIMin(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIMin(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIMin,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICustomScaleName(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICustomScaleName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMeasType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIMeasType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIMeasType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodMeasMeth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodMeasMeth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodEnableAveraging(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodEnableAveraging,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodMeasTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodMeasTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDir(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDir,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDirTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDirTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountDirDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountDirDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesInitialCnt(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesInitialCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetResetCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetResetCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesCountResetDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesCountResetDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICountEdgesDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICountEdgesDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIAngEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIAngEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIAngEncoderPulsesPerRev(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIAngEncoderPulsesPerRev,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIAngEncoderInitialAngle(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIAngEncoderInitialAngle,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCILinEncoderUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCILinEncoderUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCILinEncoderDistPerPulse(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCILinEncoderDistPerPulse,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCILinEncoderInitialPos(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCILinEncoderInitialPos,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderDecodingType(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderDecodingType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderAInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderAInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderBInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderBInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZInputDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZInputDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZIndexEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZIndexEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZIndexVal(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZIndexVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIEncoderZIndexPhase(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIEncoderZIndexPhase,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseWidthDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseWidthDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepFirstDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepFirstDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITwoEdgeSepSecondDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITwoEdgeSepSecondDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodStartingEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodStartingEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCISemiPeriodDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCISemiPeriodDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseFreqDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseFreqDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTimeDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTimeDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksStartEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksStartEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPulseTicksDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPulseTicksDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITimestampUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITimestampUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCITimestampInitialSeconds(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCITimestampInitialSeconds,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIGPSSyncMethod(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIGPSSyncMethod,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIGPSSyncSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIGPSSyncSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCICount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCIOutputState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIOutputState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIOutputState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIOutputState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCITCReached(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCITCReached,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCITCReached(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCITCReached,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCICtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCICtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIDataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIDataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIDataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIDataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCINumPossiblyInvalidSamps(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCINumPossiblyInvalidSamps,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCINumPossiblyInvalidSamps(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCINumPossiblyInvalidSamps,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIDupCountPrevent(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIDupCountPrevent,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCIPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCIPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOOutputType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOOutputType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOOutputType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseIdleState(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseIdleState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTerm(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTimeUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTimeUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseHighTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseHighTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseLowTime(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseLowTime,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTimeInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTimeInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseDutyCyc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseDutyCyc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseFreqUnits(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseFreqUnits,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseFreq(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseFreq,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseFreqInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseFreqInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseHighTicks(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseHighTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseLowTicks(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseLowTicks,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPulseTicksInitialDelay(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPulseTicksInitialDelay,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseActiveEdge(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseActiveEdge,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigFltrTimebaseRate(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseDigSyncEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseDigSyncEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOOutputState(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOOutputState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOOutputState(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOOutputState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOAutoIncrCnt(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOAutoIncrCnt,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOCtrTimebaseMasterTimebaseDiv(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOCtrTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPulseDone(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOPulseDone,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOPulseDone(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOPulseDone,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOEnableInitialDelayOnRetrigger(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOEnableInitialDelayOnRetrigger,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOConstrainedGenMode(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOConstrainedGenMode,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOUseOnlyOnBrdMem(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOUseOnlyOnBrdMem,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCODataXferMech(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCODataXferMech,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,channel,data)
+function DAQmxSetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,channel,data)
 end
 
-function DAQmxResetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCODataXferReqCond(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCODataXferReqCond,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOUsbXferReqSize(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOUsbXferReqSize,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOUsbXferReqCount(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOUsbXferReqCount,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,channel,data)
+function DAQmxSetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOMemMapEnable(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOMemMapEnable,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,channel,data)
+function DAQmxGetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,channel,data)
 end
 
-function DAQmxSetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,channel,data)
+function DAQmxSetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,channel,data)
 end
 
-function DAQmxResetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetCOPrescaler(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetCOPrescaler,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetCORdyForNewVal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetCORdyForNewVal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetCORdyForNewVal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetCORdyForNewVal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetChanType(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetChanType,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,channel,data)
+function DAQmxGetChanType(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetChanType,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,channel,data)
 end
 
-function DAQmxGetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetPhysicalChanName(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetPhysicalChanName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxGetChanDescr(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,channel,data,bufferSize)
+function DAQmxGetChanDescr(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,channel,data,bufferSize)
 end
 
-function DAQmxSetChanDescr(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,channel,data)
+function DAQmxSetChanDescr(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,channel,data)
 end
 
-function DAQmxResetChanDescr(taskHandle::TaskHandle,channel::Ptr{Uint8})
-    ccall((:DAQmxResetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,channel)
+function DAQmxResetChanDescr(taskHandle::TaskHandle,channel::Ptr{UInt8})
+    ccall((:DAQmxResetChanDescr,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,channel)
 end
 
-function DAQmxGetChanIsGlobal(taskHandle::TaskHandle,channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetChanIsGlobal,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,channel,data)
+function DAQmxGetChanIsGlobal(taskHandle::TaskHandle,channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetChanIsGlobal,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,channel,data)
 end
 
-function DAQmxGetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAIConvClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAIConvClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAIConvClkOutputTerm(taskHandle::TaskHandle)
@@ -6394,24 +6394,24 @@ function DAQmxGetExportedAIConvClkPulsePolarity(taskHandle::TaskHandle,data::Ptr
     ccall((:DAQmxGetExportedAIConvClkPulsePolarity,NIDAQmx),int32,(TaskHandle,Ptr{int32}),taskHandle,data)
 end
 
-function DAQmxGetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExported10MHzRefClkOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExported10MHzRefClkOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExported20MHzTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExported20MHzTimebaseOutputTerm(taskHandle::TaskHandle)
@@ -6430,12 +6430,12 @@ function DAQmxResetExportedSampClkOutputBehavior(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSampClkOutputBehavior,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedSampClkOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedSampClkOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedSampClkOutputTerm(taskHandle::TaskHandle)
@@ -6466,36 +6466,36 @@ function DAQmxResetExportedSampClkPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSampClkPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedSampClkTimebaseOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedDividedSampClkTimebaseOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedDividedSampClkTimebaseOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAdvTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAdvTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAdvTrigOutputTerm(taskHandle::TaskHandle)
@@ -6530,12 +6530,12 @@ function DAQmxResetExportedAdvTrigPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedAdvTrigPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedPauseTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedPauseTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedPauseTrigOutputTerm(taskHandle::TaskHandle)
@@ -6554,12 +6554,12 @@ function DAQmxResetExportedPauseTrigLvlActiveLvl(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedPauseTrigLvlActiveLvl,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedRefTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedRefTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedRefTrigOutputTerm(taskHandle::TaskHandle)
@@ -6578,12 +6578,12 @@ function DAQmxResetExportedRefTrigPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedRefTrigPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedStartTrigOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedStartTrigOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedStartTrigOutputTerm(taskHandle::TaskHandle)
@@ -6602,12 +6602,12 @@ function DAQmxResetExportedStartTrigPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedStartTrigPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAdvCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAdvCmpltEventOutputTerm(taskHandle::TaskHandle)
@@ -6650,12 +6650,12 @@ function DAQmxResetExportedAdvCmpltEventPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedAdvCmpltEventPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedAIHoldCmpltEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedAIHoldCmpltEventOutputTerm(taskHandle::TaskHandle)
@@ -6674,12 +6674,12 @@ function DAQmxResetExportedAIHoldCmpltEventPulsePolarity(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedAIHoldCmpltEventPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedChangeDetectEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedChangeDetectEventOutputTerm(taskHandle::TaskHandle)
@@ -6698,12 +6698,12 @@ function DAQmxResetExportedChangeDetectEventPulsePolarity(taskHandle::TaskHandle
     ccall((:DAQmxResetExportedChangeDetectEventPulsePolarity,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedCtrOutEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedCtrOutEventOutputTerm(taskHandle::TaskHandle)
@@ -6746,12 +6746,12 @@ function DAQmxResetExportedCtrOutEventToggleIdleState(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedCtrOutEventToggleIdleState,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedHshkEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedHshkEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedHshkEventOutputTerm(taskHandle::TaskHandle)
@@ -6842,12 +6842,12 @@ function DAQmxResetExportedHshkEventPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedHshkEventPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedRdyForXferEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedRdyForXferEventOutputTerm(taskHandle::TaskHandle)
@@ -6890,12 +6890,12 @@ function DAQmxResetExportedRdyForXferEventDeassertCondCustomThreshold(taskHandle
     ccall((:DAQmxResetExportedRdyForXferEventDeassertCondCustomThreshold,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedDataActiveEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedDataActiveEventOutputTerm(taskHandle::TaskHandle)
@@ -6914,12 +6914,12 @@ function DAQmxResetExportedDataActiveEventLvlActiveLvl(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedDataActiveEventLvlActiveLvl,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedRdyForStartEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedRdyForStartEventOutputTerm(taskHandle::TaskHandle)
@@ -6938,336 +6938,336 @@ function DAQmxResetExportedRdyForStartEventLvlActiveLvl(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedRdyForStartEventLvlActiveLvl,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedSyncPulseEventOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedSyncPulseEventOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetExportedWatchdogExpiredEventOutputTerm(taskHandle::TaskHandle)
     ccall((:DAQmxResetExportedWatchdogExpiredEventOutputTerm,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDevIsSimulated(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevIsSimulated,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevIsSimulated(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevIsSimulated,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevProductCategory(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevProductCategory,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevProductCategory(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevProductCategory,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevProductType(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevProductType,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevProductType(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevProductType,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevProductNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevProductNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevProductNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevProductNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevSerialNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevSerialNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevSerialNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevSerialNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevAccessoryProductTypes(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevAccessoryProductTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevAccessoryProductTypes(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevAccessoryProductTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAccessoryProductNums(device::Ptr{Uint8},data::Ptr{uInt32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAccessoryProductNums,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAccessoryProductNums(device::Ptr{UInt8},data::Ptr{uInt32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAccessoryProductNums,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAccessorySerialNums(device::Ptr{Uint8},data::Ptr{uInt32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAccessorySerialNums,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAccessorySerialNums(device::Ptr{UInt8},data::Ptr{uInt32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAccessorySerialNums,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetCarrierSerialNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetCarrierSerialNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetCarrierSerialNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetCarrierSerialNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevChassisModuleDevNames(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevChassisModuleDevNames,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevChassisModuleDevNames(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevChassisModuleDevNames,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAnlgTrigSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevAnlgTrigSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevAnlgTrigSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevAnlgTrigSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevDigTrigSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevDigTrigSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevDigTrigSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevDigTrigSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevAIPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevAIPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevAIPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevAIPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAISupportedMeasTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAISupportedMeasTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIMaxSingleChanRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAIMaxSingleChanRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAIMaxSingleChanRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAIMaxSingleChanRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAIMaxMultiChanRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAIMaxMultiChanRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAIMaxMultiChanRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAIMaxMultiChanRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAIMinRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAIMinRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAIMinRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAIMinRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAISimultaneousSamplingSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevAISimultaneousSamplingSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevAISimultaneousSamplingSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevAISimultaneousSamplingSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevAISampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAISampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAISampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAISampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAITrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevAITrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevAITrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevAITrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevAIVoltageRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIVoltageRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIVoltageRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIVoltageRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIVoltageIntExcitDiscreteVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIVoltageIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIVoltageIntExcitDiscreteVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIVoltageIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIVoltageIntExcitRangeVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIVoltageIntExcitRangeVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIVoltageIntExcitRangeVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIVoltageIntExcitRangeVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAICurrentRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAICurrentRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAICurrentRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAICurrentRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAICurrentIntExcitDiscreteVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAICurrentIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAICurrentIntExcitDiscreteVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAICurrentIntExcitDiscreteVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIBridgeRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIBridgeRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIBridgeRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIBridgeRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIResistanceRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIResistanceRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIResistanceRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIResistanceRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIFreqRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIFreqRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIFreqRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIFreqRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAIGains(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAIGains,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAIGains(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAIGains,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAICouplings(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevAICouplings,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevAICouplings(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevAICouplings,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevAILowpassCutoffFreqDiscreteVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAILowpassCutoffFreqDiscreteVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAILowpassCutoffFreqDiscreteVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAILowpassCutoffFreqDiscreteVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAILowpassCutoffFreqRangeVals(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAILowpassCutoffFreqRangeVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAILowpassCutoffFreqRangeVals(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAILowpassCutoffFreqRangeVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevAOPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevAOPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevAOPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevAOSupportedOutputTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOSupportedOutputTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOSampClkSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevAOSampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevAOSampClkSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevAOSampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevAOSampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOSampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOSampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOSampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOMaxRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAOMaxRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAOMaxRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAOMaxRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAOMinRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevAOMinRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevAOMinRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevAOMinRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevAOTrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevAOTrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevAOTrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevAOTrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevAOVoltageRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOVoltageRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOVoltageRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOVoltageRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOCurrentRngs(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOCurrentRngs,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOCurrentRngs(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOCurrentRngs,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevAOGains(device::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevAOGains,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevAOGains(device::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevAOGains,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevDILines(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDILines,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDILines(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDILines,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDIPorts(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDIPorts,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDIPorts(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDIPorts,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDIMaxRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevDIMaxRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevDIMaxRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevDIMaxRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevDITrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevDITrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevDITrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevDITrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevDOLines(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDOLines,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDOLines(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDOLines,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDOPorts(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevDOPorts,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevDOPorts(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevDOPorts,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevDOMaxRate(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevDOMaxRate,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevDOMaxRate(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevDOMaxRate,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevDOTrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevDOTrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevDOTrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevDOTrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevCIPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevCIPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevCIPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevCIPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevCISupportedMeasTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCISupportedMeasTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCITrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevCITrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevCITrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevCITrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevCISampClkSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevCISampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevCISampClkSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevCISampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevCISampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCISampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCISampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCISampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCIMaxSize(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevCIMaxSize,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevCIMaxSize(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevCIMaxSize,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevCIMaxTimebase(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevCIMaxTimebase,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevCIMaxTimebase(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevCIMaxTimebase,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevCOPhysicalChans(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevCOPhysicalChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevCOPhysicalChans(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevCOPhysicalChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevCOSupportedOutputTypes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCOSupportedOutputTypes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCOSampClkSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevCOSampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevCOSampClkSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevCOSampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevCOSampModes(device::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetDevCOSampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),device,data,arraySizeInElements)
+function DAQmxGetDevCOSampModes(device::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetDevCOSampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),device,data,arraySizeInElements)
 end
 
-function DAQmxGetDevCOTrigUsage(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevCOTrigUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevCOTrigUsage(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevCOTrigUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevCOMaxSize(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevCOMaxSize,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevCOMaxSize(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevCOMaxSize,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevCOMaxTimebase(device::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDevCOMaxTimebase,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),device,data)
+function DAQmxGetDevCOMaxTimebase(device::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDevCOMaxTimebase,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),device,data)
 end
 
-function DAQmxGetDevTEDSHWTEDSSupported(device::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetDevTEDSHWTEDSSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),device,data)
+function DAQmxGetDevTEDSHWTEDSSupported(device::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetDevTEDSHWTEDSSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),device,data)
 end
 
-function DAQmxGetDevNumDMAChans(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevNumDMAChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevNumDMAChans(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevNumDMAChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevBusType(device::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDevBusType,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),device,data)
+function DAQmxGetDevBusType(device::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDevBusType,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),device,data)
 end
 
-function DAQmxGetDevPCIBusNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPCIBusNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPCIBusNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPCIBusNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevPCIDevNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPCIDevNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPCIDevNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPCIDevNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevPXIChassisNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPXIChassisNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPXIChassisNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPXIChassisNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevPXISlotNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevPXISlotNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevPXISlotNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevPXISlotNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevCompactDAQChassisDevName(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevCompactDAQChassisDevName,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevCompactDAQChassisDevName(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevCompactDAQChassisDevName,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevCompactDAQSlotNum(device::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetDevCompactDAQSlotNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),device,data)
+function DAQmxGetDevCompactDAQSlotNum(device::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetDevCompactDAQSlotNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),device,data)
 end
 
-function DAQmxGetDevTCPIPHostname(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTCPIPHostname,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTCPIPHostname(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTCPIPHostname,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevTCPIPEthernetIP(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTCPIPEthernetIP,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTCPIPEthernetIP(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTCPIPEthernetIP,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevTCPIPWirelessIP(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTCPIPWirelessIP,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTCPIPWirelessIP(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTCPIPWirelessIP,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
-function DAQmxGetDevTerminals(device::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDevTerminals,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),device,data,bufferSize)
+function DAQmxGetDevTerminals(device::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDevTerminals,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),device,data,bufferSize)
 end
 
 function DAQmxGetReadRelativeTo(taskHandle::TaskHandle,data::Ptr{int32})
@@ -7294,12 +7294,12 @@ function DAQmxResetReadOffset(taskHandle::TaskHandle)
     ccall((:DAQmxResetReadOffset,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetReadChannelsToRead(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetReadChannelsToRead,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetReadChannelsToRead(taskHandle::TaskHandle)
@@ -7350,12 +7350,12 @@ function DAQmxGetReadAvailSampPerChan(taskHandle::TaskHandle,data::Ptr{uInt32})
     ccall((:DAQmxGetReadAvailSampPerChan,NIDAQmx),int32,(TaskHandle,Ptr{uInt32}),taskHandle,data)
 end
 
-function DAQmxGetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetLoggingFilePath(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetLoggingFilePath,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetLoggingFilePath(taskHandle::TaskHandle)
@@ -7374,12 +7374,12 @@ function DAQmxResetLoggingMode(taskHandle::TaskHandle)
     ccall((:DAQmxResetLoggingMode,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetLoggingTDMSGroupName(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetLoggingTDMSGroupName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetLoggingTDMSGroupName(taskHandle::TaskHandle)
@@ -7454,48 +7454,48 @@ function DAQmxGetReadCommonModeRangeErrorChansExist(taskHandle::TaskHandle,data:
     ccall((:DAQmxGetReadCommonModeRangeErrorChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadCommonModeRangeErrorChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadCommonModeRangeErrorChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadCommonModeRangeErrorChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadCommonModeRangeErrorChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOvercurrentChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOvercurrentChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOvercurrentChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOvercurrentChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOpenCurrentLoopChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOpenCurrentLoopChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOpenThrmcplChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOpenThrmcplChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOpenThrmcplChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOpenThrmcplChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOpenThrmcplChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOpenThrmcplChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadOverloadedChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadOverloadedChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadOverloadedChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadOverloadedChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadOverloadedChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadAccessoryInsertionOrRemovalDetected(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetReadAccessoryInsertionOrRemovalDetected,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetReadDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetReadDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetReadDevsWithInsertedOrRemovedAccessories(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetReadDevsWithInsertedOrRemovedAccessories,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetReadChangeDetectHasOverflowed(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -7598,132 +7598,132 @@ function DAQmxResetRealTimeWriteRecoveryMode(taskHandle::TaskHandle)
     ccall((:DAQmxResetRealTimeWriteRecoveryMode,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSwitchChanUsage(switchChannelName::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetSwitchChanUsage,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),switchChannelName,data)
+function DAQmxGetSwitchChanUsage(switchChannelName::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetSwitchChanUsage,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),switchChannelName,data)
 end
 
-function DAQmxSetSwitchChanUsage(switchChannelName::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetSwitchChanUsage,NIDAQmx),int32,(Ptr{Uint8},int32),switchChannelName,data)
+function DAQmxSetSwitchChanUsage(switchChannelName::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetSwitchChanUsage,NIDAQmx),int32,(Ptr{UInt8},int32),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),switchChannelName,data)
+function DAQmxGetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),switchChannelName,data)
 end
 
-function DAQmxSetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{Uint8},bool32),switchChannelName,data)
+function DAQmxSetSwitchChanAnlgBusSharingEnable(switchChannelName::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetSwitchChanAnlgBusSharingEnable,NIDAQmx),int32,(Ptr{UInt8},bool32),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACCarryCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACCarryCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACCarryCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACCarryCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACSwitchCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACSwitchCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACSwitchCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACSwitchCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACCarryPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACCarryPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACCarryPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACCarryPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACSwitchPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACSwitchPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACSwitchPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACSwitchPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCCarryCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCCarryCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCCarryCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCCarryCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCSwitchCurrent(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCSwitchCurrent,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCSwitchCurrent(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCSwitchCurrent,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCCarryPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCCarryPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCCarryPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCCarryPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCSwitchPwr(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCSwitchPwr,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCSwitchPwr(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCSwitchPwr,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxACVoltage(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxACVoltage,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxACVoltage(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxACVoltage,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanMaxDCVoltage(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanMaxDCVoltage,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanMaxDCVoltage(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanMaxDCVoltage,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanWireMode(switchChannelName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchChanWireMode,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),switchChannelName,data)
+function DAQmxGetSwitchChanWireMode(switchChannelName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchChanWireMode,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanBandwidth(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanBandwidth,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanBandwidth(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanBandwidth,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchChanImpedance(switchChannelName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchChanImpedance,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),switchChannelName,data)
+function DAQmxGetSwitchChanImpedance(switchChannelName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchChanImpedance,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),switchChannelName,data)
 end
 
-function DAQmxGetSwitchDevSettlingTime(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetSwitchDevSettlingTime(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
-function DAQmxSetSwitchDevSettlingTime(deviceName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{Uint8},float64),deviceName,data)
+function DAQmxSetSwitchDevSettlingTime(deviceName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetSwitchDevSettlingTime,NIDAQmx),int32,(Ptr{UInt8},float64),deviceName,data)
 end
 
-function DAQmxGetSwitchDevAutoConnAnlgBus(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSwitchDevAutoConnAnlgBus(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxSetSwitchDevAutoConnAnlgBus(deviceName::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,data)
+function DAQmxSetSwitchDevAutoConnAnlgBus(deviceName::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetSwitchDevAutoConnAnlgBus,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,data)
 end
 
-function DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{Uint8},bool32),deviceName,data)
+function DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling(deviceName::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetSwitchDevPwrDownLatchRelaysAfterSettling,NIDAQmx),int32,(Ptr{UInt8},bool32),deviceName,data)
 end
 
-function DAQmxGetSwitchDevSettled(deviceName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetSwitchDevSettled,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),deviceName,data)
+function DAQmxGetSwitchDevSettled(deviceName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetSwitchDevSettled,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevRelayList(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSwitchDevRelayList,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetSwitchDevRelayList(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSwitchDevRelayList,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxGetSwitchDevNumRelays(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumRelays,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumRelays(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumRelays,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevSwitchChanList(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSwitchDevSwitchChanList,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetSwitchDevSwitchChanList(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSwitchDevSwitchChanList,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxGetSwitchDevNumSwitchChans(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumSwitchChans,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumSwitchChans(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumSwitchChans,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevNumRows(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumRows,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumRows(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumRows,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevNumColumns(deviceName::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetSwitchDevNumColumns,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),deviceName,data)
+function DAQmxGetSwitchDevNumColumns(deviceName::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetSwitchDevNumColumns,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),deviceName,data)
 end
 
-function DAQmxGetSwitchDevTopology(deviceName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSwitchDevTopology,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),deviceName,data,bufferSize)
+function DAQmxGetSwitchDevTopology(deviceName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSwitchDevTopology,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),deviceName,data,bufferSize)
 end
 
-function DAQmxGetSwitchDevTemperature(deviceName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetSwitchDevTemperature,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),deviceName,data)
+function DAQmxGetSwitchDevTemperature(deviceName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetSwitchDevTemperature,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),deviceName,data)
 end
 
 function DAQmxGetSwitchScanBreakMode(taskHandle::TaskHandle,data::Ptr{int32})
@@ -7754,128 +7754,128 @@ function DAQmxGetSwitchScanWaitingForAdv(taskHandle::TaskHandle,data::Ptr{bool32
     ccall((:DAQmxGetSwitchScanWaitingForAdv,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetScaleDescr(scaleName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetScaleDescr,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,data,bufferSize)
+function DAQmxGetScaleDescr(scaleName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetScaleDescr,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,data,bufferSize)
 end
 
-function DAQmxSetScaleDescr(scaleName::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetScaleDescr,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),scaleName,data)
+function DAQmxSetScaleDescr(scaleName::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetScaleDescr,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),scaleName,data)
 end
 
-function DAQmxGetScaleScaledUnits(scaleName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetScaleScaledUnits,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,data,bufferSize)
+function DAQmxGetScaleScaledUnits(scaleName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetScaleScaledUnits,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,data,bufferSize)
 end
 
-function DAQmxSetScaleScaledUnits(scaleName::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetScaleScaledUnits,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8}),scaleName,data)
+function DAQmxSetScaleScaledUnits(scaleName::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetScaleScaledUnits,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8}),scaleName,data)
 end
 
-function DAQmxGetScalePreScaledUnits(scaleName::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetScalePreScaledUnits,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),scaleName,data)
+function DAQmxGetScalePreScaledUnits(scaleName::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetScalePreScaledUnits,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),scaleName,data)
 end
 
-function DAQmxSetScalePreScaledUnits(scaleName::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetScalePreScaledUnits,NIDAQmx),int32,(Ptr{Uint8},int32),scaleName,data)
+function DAQmxSetScalePreScaledUnits(scaleName::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetScalePreScaledUnits,NIDAQmx),int32,(Ptr{UInt8},int32),scaleName,data)
 end
 
-function DAQmxGetScaleType(scaleName::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetScaleType,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),scaleName,data)
+function DAQmxGetScaleType(scaleName::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetScaleType,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),scaleName,data)
 end
 
-function DAQmxGetScaleLinSlope(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleLinSlope,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleLinSlope(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleLinSlope,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleLinSlope(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleLinSlope,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleLinSlope(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleLinSlope,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleLinYIntercept(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleLinYIntercept,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleLinYIntercept(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleLinYIntercept,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleLinYIntercept(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleLinYIntercept,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleLinYIntercept(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleLinYIntercept,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapScaledMax(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapScaledMax,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapScaledMax(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapScaledMax,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapScaledMax(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapScaledMax,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapScaledMax(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapScaledMax,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapPreScaledMax(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapPreScaledMax(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapPreScaledMax(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapPreScaledMax(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapPreScaledMax,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapScaledMin(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapScaledMin,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapScaledMin(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapScaledMin,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapScaledMin(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapScaledMin,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapScaledMin(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapScaledMin,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScaleMapPreScaledMin(scaleName::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),scaleName,data)
+function DAQmxGetScaleMapPreScaledMin(scaleName::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),scaleName,data)
 end
 
-function DAQmxSetScaleMapPreScaledMin(scaleName::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{Uint8},float64),scaleName,data)
+function DAQmxSetScaleMapPreScaledMin(scaleName::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetScaleMapPreScaledMin,NIDAQmx),int32,(Ptr{UInt8},float64),scaleName,data)
 end
 
-function DAQmxGetScalePolyForwardCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScalePolyForwardCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScalePolyForwardCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScalePolyForwardCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScalePolyForwardCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetScalePolyReverseCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScalePolyReverseCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScalePolyReverseCoeff(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScalePolyReverseCoeff(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScalePolyReverseCoeff,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetScaleTableScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScaleTableScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScaleTableScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScaleTableScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScaleTableScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScaleTableScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScaleTableScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScaleTableScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetScaleTablePreScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxGetScaleTablePreScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxSetScaleTablePreScaledVals(scaleName::Ptr{Uint8},data::Ptr{float64},arraySizeInElements::uInt32)
-    ccall((:DAQmxSetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
+function DAQmxSetScaleTablePreScaledVals(scaleName::Ptr{UInt8},data::Ptr{float64},arraySizeInElements::uInt32)
+    ccall((:DAQmxSetScaleTablePreScaledVals,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64},uInt32),scaleName,data,arraySizeInElements)
 end
 
-function DAQmxGetSysGlobalChans(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysGlobalChans,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysGlobalChans(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysGlobalChans,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
-function DAQmxGetSysScales(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysScales,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysScales(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysScales,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
-function DAQmxGetSysTasks(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysTasks,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysTasks(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysTasks,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
-function DAQmxGetSysDevNames(data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSysDevNames,NIDAQmx),int32,(Ptr{Uint8},uInt32),data,bufferSize)
+function DAQmxGetSysDevNames(data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSysDevNames,NIDAQmx),int32,(Ptr{UInt8},uInt32),data,bufferSize)
 end
 
 function DAQmxGetSysNIDAQMajorVersion(data::Ptr{uInt32})
@@ -7890,20 +7890,20 @@ function DAQmxGetSysNIDAQUpdateVersion(data::Ptr{uInt32})
     ccall((:DAQmxGetSysNIDAQUpdateVersion,NIDAQmx),int32,(Ptr{uInt32},),data)
 end
 
-function DAQmxGetTaskName(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetTaskName,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetTaskName(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetTaskName,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetTaskChannels(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetTaskChannels,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetTaskChannels(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetTaskChannels,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetTaskNumChans(taskHandle::TaskHandle,data::Ptr{uInt32})
     ccall((:DAQmxGetTaskNumChans,NIDAQmx),int32,(TaskHandle,Ptr{uInt32}),taskHandle,data)
 end
 
-function DAQmxGetTaskDevices(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetTaskDevices,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetTaskDevices(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetTaskDevices,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetTaskNumDevices(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -7966,12 +7966,12 @@ function DAQmxGetSampClkMaxRate(taskHandle::TaskHandle,data::Ptr{float64})
     ccall((:DAQmxGetSampClkMaxRate,NIDAQmx),int32,(TaskHandle,Ptr{float64}),taskHandle,data)
 end
 
-function DAQmxGetSampClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSampClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSampClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSampClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSampClkSrc(taskHandle::TaskHandle)
@@ -8026,8 +8026,8 @@ function DAQmxResetSampClkTimebaseDiv(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkTimebaseDiv,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetSampClkTimebaseRate(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8042,12 +8042,12 @@ function DAQmxResetSampClkTimebaseRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkTimebaseRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSampClkTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSampClkTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSampClkTimebaseSrc(taskHandle::TaskHandle)
@@ -8078,8 +8078,8 @@ function DAQmxResetSampClkTimebaseMasterTimebaseDiv(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkTimebaseMasterTimebaseDiv,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkTimebaseTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkTimebaseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkTimebaseTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkTimebaseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetSampClkDigFltrEnable(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -8106,12 +8106,12 @@ function DAQmxResetSampClkDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetSampClkDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSampClkDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSampClkDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -8178,24 +8178,24 @@ function DAQmxResetHshkSampleInputDataWhen(taskHandle::TaskHandle)
     ccall((:DAQmxResetHshkSampleInputDataWhen,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetChangeDetectDIRisingEdgePhysicalChans(taskHandle::TaskHandle)
     ccall((:DAQmxResetChangeDetectDIRisingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetChangeDetectDIFallingEdgePhysicalChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetChangeDetectDIFallingEdgePhysicalChans(taskHandle::TaskHandle)
@@ -8250,48 +8250,48 @@ function DAQmxResetAIConvRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvMaxRate(taskHandle::TaskHandle,data::Ptr{float64})
     ccall((:DAQmxGetAIConvMaxRate,NIDAQmx),int32,(TaskHandle,Ptr{float64}),taskHandle,data)
 end
 
-function DAQmxGetAIConvMaxRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvMaxRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvMaxRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvMaxRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxGetAIConvSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAIConvSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAIConvSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAIConvSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAIConvSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,deviceNames,data,bufferSize)
+function DAQmxGetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,deviceNames,data,bufferSize)
 end
 
-function DAQmxSetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,deviceNames,data)
+function DAQmxSetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvActiveEdge(taskHandle::TaskHandle,data::Ptr{int32})
@@ -8306,16 +8306,16 @@ function DAQmxResetAIConvActiveEdge(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvActiveEdge,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvActiveEdgeEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvActiveEdgeEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvTimebaseDiv(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -8330,16 +8330,16 @@ function DAQmxResetAIConvTimebaseDiv(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvTimebaseDiv,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{uInt32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{uInt32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::uInt32)
-    ccall((:DAQmxSetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::uInt32)
+    ccall((:DAQmxSetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvTimebaseDivEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvTimebaseDivEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvTimebaseSrc(taskHandle::TaskHandle,data::Ptr{int32})
@@ -8354,16 +8354,16 @@ function DAQmxResetAIConvTimebaseSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvTimebaseSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetDelayFromSampClkDelayUnits(taskHandle::TaskHandle,data::Ptr{int32})
@@ -8378,16 +8378,16 @@ function DAQmxResetDelayFromSampClkDelayUnits(taskHandle::TaskHandle)
     ccall((:DAQmxResetDelayFromSampClkDelayUnits,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,deviceNames,data)
+function DAQmxGetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,deviceNames,data)
+function DAQmxSetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetDelayFromSampClkDelayUnitsEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetDelayFromSampClkDelayUnitsEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetDelayFromSampClkDelay(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8402,16 +8402,16 @@ function DAQmxResetDelayFromSampClkDelay(taskHandle::TaskHandle)
     ccall((:DAQmxResetDelayFromSampClkDelay,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetDelayFromSampClkDelayEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetDelayFromSampClkDelayEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigFltrEnable(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -8426,16 +8426,16 @@ function DAQmxResetAIConvDigFltrEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigFltrMinPulseWidth(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8450,40 +8450,40 @@ function DAQmxResetAIConvDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrMinPulseWidthEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrMinPulseWidthEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
-function DAQmxGetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAIConvDigFltrTimebaseSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8},uInt32),taskHandle,deviceNames,data,bufferSize)
+function DAQmxGetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8},uInt32),taskHandle,deviceNames,data,bufferSize)
 end
 
-function DAQmxSetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{Uint8})
-    ccall((:DAQmxSetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{Uint8}),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{UInt8})
+    ccall((:DAQmxSetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{UInt8}),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrTimebaseSrcEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrTimebaseSrcEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigFltrTimebaseRate(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8498,16 +8498,16 @@ function DAQmxResetAIConvDigFltrTimebaseRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigFltrTimebaseRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{float64}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{float64}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::float64)
-    ccall((:DAQmxSetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},float64),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::float64)
+    ccall((:DAQmxSetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},float64),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigFltrTimebaseRateEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigFltrTimebaseRateEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetAIConvDigSyncEnable(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -8522,16 +8522,16 @@ function DAQmxResetAIConvDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAIConvDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{bool32}),taskHandle,deviceNames,data)
+function DAQmxGetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{bool32}),taskHandle,deviceNames,data)
 end
 
-function DAQmxSetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},bool32),taskHandle,deviceNames,data)
+function DAQmxSetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},bool32),taskHandle,deviceNames,data)
 end
 
-function DAQmxResetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{Uint8})
-    ccall((:DAQmxResetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,deviceNames)
+function DAQmxResetAIConvDigSyncEnableEx(taskHandle::TaskHandle,deviceNames::Ptr{UInt8})
+    ccall((:DAQmxResetAIConvDigSyncEnableEx,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,deviceNames)
 end
 
 function DAQmxGetMasterTimebaseRate(taskHandle::TaskHandle,data::Ptr{float64})
@@ -8546,12 +8546,12 @@ function DAQmxResetMasterTimebaseRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetMasterTimebaseRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetMasterTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetMasterTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetMasterTimebaseSrc(taskHandle::TaskHandle)
@@ -8570,24 +8570,24 @@ function DAQmxResetRefClkRate(taskHandle::TaskHandle)
     ccall((:DAQmxResetRefClkRate,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetRefClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetRefClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetRefClkSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetRefClkSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetRefClkSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetRefClkSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetRefClkSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetSyncPulseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetSyncPulseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetSyncPulseSrc(taskHandle::TaskHandle)
@@ -8626,8 +8626,8 @@ function DAQmxResetSyncPulseResetDelay(taskHandle::TaskHandle)
     ccall((:DAQmxResetSyncPulseResetDelay,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetSyncPulseTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetSyncPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetSyncPulseTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetSyncPulseTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetSyncClkInterval(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -8666,16 +8666,16 @@ function DAQmxResetStartTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetStartTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetStartTrigTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetStartTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetStartTrigTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetStartTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeStartTrigSrc(taskHandle::TaskHandle)
@@ -8718,12 +8718,12 @@ function DAQmxResetDigEdgeStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -8754,24 +8754,24 @@ function DAQmxResetDigEdgeStartTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeStartTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternStartTrigSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternStartTrigSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternStartTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternStartTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternStartTrigPattern(taskHandle::TaskHandle)
@@ -8790,12 +8790,12 @@ function DAQmxResetDigPatternStartTrigWhen(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternStartTrigWhen,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeStartTrigSrc(taskHandle::TaskHandle)
@@ -8874,12 +8874,12 @@ function DAQmxResetAnlgEdgeStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -8910,12 +8910,12 @@ function DAQmxResetAnlgEdgeStartTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeStartTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinStartTrigSrc(taskHandle::TaskHandle)
@@ -8994,12 +8994,12 @@ function DAQmxResetAnlgWinStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9090,16 +9090,16 @@ function DAQmxResetRefTrigPretrigSamples(taskHandle::TaskHandle)
     ccall((:DAQmxResetRefTrigPretrigSamples,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetRefTrigTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetRefTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetRefTrigTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetRefTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeRefTrigSrc(taskHandle::TaskHandle)
@@ -9142,12 +9142,12 @@ function DAQmxResetDigEdgeRefTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeRefTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9178,24 +9178,24 @@ function DAQmxResetDigEdgeRefTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeRefTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternRefTrigSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternRefTrigSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternRefTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternRefTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternRefTrigPattern(taskHandle::TaskHandle)
@@ -9214,12 +9214,12 @@ function DAQmxResetDigPatternRefTrigWhen(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternRefTrigWhen,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeRefTrigSrc(taskHandle::TaskHandle)
@@ -9298,12 +9298,12 @@ function DAQmxResetAnlgEdgeRefTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeRefTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgEdgeRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgEdgeRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9334,12 +9334,12 @@ function DAQmxResetAnlgEdgeRefTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgEdgeRefTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinRefTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinRefTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinRefTrigSrc(taskHandle::TaskHandle)
@@ -9418,12 +9418,12 @@ function DAQmxResetAnlgWinRefTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinRefTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinRefTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinRefTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9494,12 +9494,12 @@ function DAQmxResetAdvTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetAdvTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeAdvTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeAdvTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeAdvTrigSrc(taskHandle::TaskHandle)
@@ -9542,12 +9542,12 @@ function DAQmxResetHshkTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetHshkTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetInterlockedHshkTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetInterlockedHshkTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetInterlockedHshkTrigSrc(taskHandle::TaskHandle)
@@ -9578,16 +9578,16 @@ function DAQmxResetPauseTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetPauseTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetPauseTrigTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPauseTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetPauseTrigTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPauseTrigTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgLvlPauseTrigSrc(taskHandle::TaskHandle)
@@ -9666,12 +9666,12 @@ function DAQmxResetAnlgLvlPauseTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgLvlPauseTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9702,12 +9702,12 @@ function DAQmxResetAnlgLvlPauseTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgLvlPauseTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinPauseTrigSrc(taskHandle::TaskHandle)
@@ -9786,12 +9786,12 @@ function DAQmxResetAnlgWinPauseTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinPauseTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetAnlgWinPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetAnlgWinPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9822,12 +9822,12 @@ function DAQmxResetAnlgWinPauseTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetAnlgWinPauseTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigLvlPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigLvlPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigLvlPauseTrigSrc(taskHandle::TaskHandle)
@@ -9870,12 +9870,12 @@ function DAQmxResetDigLvlPauseTrigDigFltrMinPulseWidth(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigLvlPauseTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigLvlPauseTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigLvlPauseTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -9906,24 +9906,24 @@ function DAQmxResetDigLvlPauseTrigDigSyncEnable(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigLvlPauseTrigDigSyncEnable,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternPauseTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternPauseTrigSrc(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigPatternPauseTrigSrc,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigPatternPauseTrigPattern(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigPatternPauseTrigPattern,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigPatternPauseTrigPattern(taskHandle::TaskHandle)
@@ -9954,16 +9954,16 @@ function DAQmxResetArmStartTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetArmStartTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetArmStartTerm(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetArmStartTerm,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetArmStartTerm(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetArmStartTerm,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxGetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeArmStartTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeArmStartTrigSrc(taskHandle::TaskHandle)
@@ -10006,12 +10006,12 @@ function DAQmxResetDigEdgeArmStartTrigDigFltrMinPulseWidth(taskHandle::TaskHandl
     ccall((:DAQmxResetDigEdgeArmStartTrigDigFltrMinPulseWidth,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeArmStartTrigDigFltrTimebaseSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeArmStartTrigDigFltrTimebaseSrc(taskHandle::TaskHandle)
@@ -10078,12 +10078,12 @@ function DAQmxResetWatchdogExpirTrigType(taskHandle::TaskHandle)
     ccall((:DAQmxResetWatchdogExpirTrigType,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
-function DAQmxSetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{Uint8})
-    ccall((:DAQmxSetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,data)
+function DAQmxSetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle,data::Ptr{UInt8})
+    ccall((:DAQmxSetDigEdgeWatchdogExpirTrigSrc,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,data)
 end
 
 function DAQmxResetDigEdgeWatchdogExpirTrigSrc(taskHandle::TaskHandle)
@@ -10102,16 +10102,16 @@ function DAQmxResetDigEdgeWatchdogExpirTrigEdge(taskHandle::TaskHandle)
     ccall((:DAQmxResetDigEdgeWatchdogExpirTrigEdge,NIDAQmx),int32,(TaskHandle,),taskHandle)
 end
 
-function DAQmxGetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},Ptr{int32}),taskHandle,lines,data)
+function DAQmxGetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},Ptr{int32}),taskHandle,lines,data)
 end
 
-function DAQmxSetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8},data::int32)
-    ccall((:DAQmxSetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},int32),taskHandle,lines,data)
+function DAQmxSetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8},data::int32)
+    ccall((:DAQmxSetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},int32),taskHandle,lines,data)
 end
 
-function DAQmxResetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{Uint8})
-    ccall((:DAQmxResetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{Uint8}),taskHandle,lines)
+function DAQmxResetWatchdogDOExpirState(taskHandle::TaskHandle,lines::Ptr{UInt8})
+    ccall((:DAQmxResetWatchdogDOExpirState,NIDAQmx),int32,(TaskHandle,Ptr{UInt8}),taskHandle,lines)
 end
 
 function DAQmxGetWatchdogHasExpired(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -10162,8 +10162,8 @@ function DAQmxGetWriteOvercurrentChansExist(taskHandle::TaskHandle,data::Ptr{boo
     ccall((:DAQmxGetWriteOvercurrentChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOvercurrentChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOvercurrentChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOvercurrentChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteOvertemperatureChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
@@ -10174,16 +10174,16 @@ function DAQmxGetWriteOpenCurrentLoopChansExist(taskHandle::TaskHandle,data::Ptr
     ccall((:DAQmxGetWriteOpenCurrentLoopChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWriteOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWriteOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWriteOpenCurrentLoopChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWriteOpenCurrentLoopChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWritePowerSupplyFaultChansExist(taskHandle::TaskHandle,data::Ptr{bool32})
     ccall((:DAQmxGetWritePowerSupplyFaultChansExist,NIDAQmx),int32,(TaskHandle,Ptr{bool32}),taskHandle,data)
 end
 
-function DAQmxGetWritePowerSupplyFaultChans(taskHandle::TaskHandle,data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetWritePowerSupplyFaultChans,NIDAQmx),int32,(TaskHandle,Ptr{Uint8},uInt32),taskHandle,data,bufferSize)
+function DAQmxGetWritePowerSupplyFaultChans(taskHandle::TaskHandle,data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetWritePowerSupplyFaultChans,NIDAQmx),int32,(TaskHandle,Ptr{UInt8},uInt32),taskHandle,data,bufferSize)
 end
 
 function DAQmxGetWriteSpaceAvail(taskHandle::TaskHandle,data::Ptr{uInt32})
@@ -10242,148 +10242,148 @@ function DAQmxGetWriteDigitalLinesBytesPerChan(taskHandle::TaskHandle,data::Ptr{
     ccall((:DAQmxGetWriteDigitalLinesBytesPerChan,NIDAQmx),int32,(TaskHandle,Ptr{uInt32}),taskHandle,data)
 end
 
-function DAQmxGetPhysicalChanAISupportedMeasTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanAISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanAISupportedMeasTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanAISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanAITermCfgs(physicalChannel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetPhysicalChanAITermCfgs,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAITermCfgs(physicalChannel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetPhysicalChanAITermCfgs,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAIInputSrcs(physicalChannel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPhysicalChanAIInputSrcs,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),physicalChannel,data,bufferSize)
+function DAQmxGetPhysicalChanAIInputSrcs(physicalChannel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPhysicalChanAIInputSrcs,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),physicalChannel,data,bufferSize)
 end
 
-function DAQmxGetPhysicalChanAOSupportedOutputTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanAOSupportedOutputTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanAOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanAOTermCfgs(physicalChannel::Ptr{Uint8},data::Ptr{int32})
-    ccall((:DAQmxGetPhysicalChanAOTermCfgs,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOTermCfgs(physicalChannel::Ptr{UInt8},data::Ptr{int32})
+    ccall((:DAQmxGetPhysicalChanAOTermCfgs,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxSetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{Uint8},data::bool32)
-    ccall((:DAQmxSetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{Uint8},bool32),physicalChannel,data)
+function DAQmxSetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{UInt8},data::bool32)
+    ccall((:DAQmxSetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{UInt8},bool32),physicalChannel,data)
 end
 
-function DAQmxResetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{Uint8})
-    ccall((:DAQmxResetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{Uint8},),physicalChannel)
+function DAQmxResetPhysicalChanAOManualControlEnable(physicalChannel::Ptr{UInt8})
+    ccall((:DAQmxResetPhysicalChanAOManualControlEnable,NIDAQmx),int32,(Ptr{UInt8},),physicalChannel)
 end
 
-function DAQmxGetPhysicalChanAOManualControlShortDetected(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanAOManualControlShortDetected,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlShortDetected(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanAOManualControlShortDetected,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAOManualControlAmplitude(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetPhysicalChanAOManualControlAmplitude,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlAmplitude(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetPhysicalChanAOManualControlAmplitude,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanAOManualControlFreq(physicalChannel::Ptr{Uint8},data::Ptr{float64})
-    ccall((:DAQmxGetPhysicalChanAOManualControlFreq,NIDAQmx),int32,(Ptr{Uint8},Ptr{float64}),physicalChannel,data)
+function DAQmxGetPhysicalChanAOManualControlFreq(physicalChannel::Ptr{UInt8},data::Ptr{float64})
+    ccall((:DAQmxGetPhysicalChanAOManualControlFreq,NIDAQmx),int32,(Ptr{UInt8},Ptr{float64}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDIPortWidth(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanDIPortWidth,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDIPortWidth(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanDIPortWidth,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDISampClkSupported(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanDISampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDISampClkSupported(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanDISampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDISampModes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanDISampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanDISampModes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanDISampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanDIChangeDetectSupported(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanDIChangeDetectSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDIChangeDetectSupported(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanDIChangeDetectSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDOPortWidth(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanDOPortWidth,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDOPortWidth(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanDOPortWidth,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDOSampClkSupported(physicalChannel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPhysicalChanDOSampClkSupported,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),physicalChannel,data)
+function DAQmxGetPhysicalChanDOSampClkSupported(physicalChannel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPhysicalChanDOSampClkSupported,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanDOSampModes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanDOSampModes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanDOSampModes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanDOSampModes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanCISupportedMeasTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanCISupportedMeasTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanCISupportedMeasTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanCISupportedMeasTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanCOSupportedOutputTypes(physicalChannel::Ptr{Uint8},data::Ptr{int32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{Uint8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanCOSupportedOutputTypes(physicalChannel::Ptr{UInt8},data::Ptr{int32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanCOSupportedOutputTypes,NIDAQmx),int32,(Ptr{UInt8},Ptr{int32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanTEDSMfgID(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSMfgID,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSMfgID(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSMfgID,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSModelNum(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSModelNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSModelNum(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSModelNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSSerialNum(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSSerialNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSSerialNum(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSSerialNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSVersionNum(physicalChannel::Ptr{Uint8},data::Ptr{uInt32})
-    ccall((:DAQmxGetPhysicalChanTEDSVersionNum,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32}),physicalChannel,data)
+function DAQmxGetPhysicalChanTEDSVersionNum(physicalChannel::Ptr{UInt8},data::Ptr{uInt32})
+    ccall((:DAQmxGetPhysicalChanTEDSVersionNum,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32}),physicalChannel,data)
 end
 
-function DAQmxGetPhysicalChanTEDSVersionLetter(physicalChannel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPhysicalChanTEDSVersionLetter,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),physicalChannel,data,bufferSize)
+function DAQmxGetPhysicalChanTEDSVersionLetter(physicalChannel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPhysicalChanTEDSVersionLetter,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),physicalChannel,data,bufferSize)
 end
 
-function DAQmxGetPhysicalChanTEDSBitStream(physicalChannel::Ptr{Uint8},data::Ptr{uInt8},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanTEDSBitStream,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt8},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanTEDSBitStream(physicalChannel::Ptr{UInt8},data::Ptr{uInt8},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanTEDSBitStream,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt8},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPhysicalChanTEDSTemplateIDs(physicalChannel::Ptr{Uint8},data::Ptr{uInt32},arraySizeInElements::uInt32)
-    ccall((:DAQmxGetPhysicalChanTEDSTemplateIDs,NIDAQmx),int32,(Ptr{Uint8},Ptr{uInt32},uInt32),physicalChannel,data,arraySizeInElements)
+function DAQmxGetPhysicalChanTEDSTemplateIDs(physicalChannel::Ptr{UInt8},data::Ptr{uInt32},arraySizeInElements::uInt32)
+    ccall((:DAQmxGetPhysicalChanTEDSTemplateIDs,NIDAQmx),int32,(Ptr{UInt8},Ptr{uInt32},uInt32),physicalChannel,data,arraySizeInElements)
 end
 
-function DAQmxGetPersistedTaskAuthor(taskName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPersistedTaskAuthor,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),taskName,data,bufferSize)
+function DAQmxGetPersistedTaskAuthor(taskName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPersistedTaskAuthor,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),taskName,data,bufferSize)
 end
 
-function DAQmxGetPersistedTaskAllowInteractiveEditing(taskName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedTaskAllowInteractiveEditing,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),taskName,data)
+function DAQmxGetPersistedTaskAllowInteractiveEditing(taskName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedTaskAllowInteractiveEditing,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),taskName,data)
 end
 
-function DAQmxGetPersistedTaskAllowInteractiveDeletion(taskName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedTaskAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),taskName,data)
+function DAQmxGetPersistedTaskAllowInteractiveDeletion(taskName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedTaskAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),taskName,data)
 end
 
-function DAQmxGetPersistedChanAuthor(channel::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPersistedChanAuthor,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),channel,data,bufferSize)
+function DAQmxGetPersistedChanAuthor(channel::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPersistedChanAuthor,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),channel,data,bufferSize)
 end
 
-function DAQmxGetPersistedChanAllowInteractiveEditing(channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedChanAllowInteractiveEditing,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),channel,data)
+function DAQmxGetPersistedChanAllowInteractiveEditing(channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedChanAllowInteractiveEditing,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),channel,data)
 end
 
-function DAQmxGetPersistedChanAllowInteractiveDeletion(channel::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedChanAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),channel,data)
+function DAQmxGetPersistedChanAllowInteractiveDeletion(channel::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedChanAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),channel,data)
 end
 
-function DAQmxGetPersistedScaleAuthor(scaleName::Ptr{Uint8},data::Ptr{Uint8},bufferSize::uInt32)
-    ccall((:DAQmxGetPersistedScaleAuthor,NIDAQmx),int32,(Ptr{Uint8},Ptr{Uint8},uInt32),scaleName,data,bufferSize)
+function DAQmxGetPersistedScaleAuthor(scaleName::Ptr{UInt8},data::Ptr{UInt8},bufferSize::uInt32)
+    ccall((:DAQmxGetPersistedScaleAuthor,NIDAQmx),int32,(Ptr{UInt8},Ptr{UInt8},uInt32),scaleName,data,bufferSize)
 end
 
-function DAQmxGetPersistedScaleAllowInteractiveEditing(scaleName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedScaleAllowInteractiveEditing,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),scaleName,data)
+function DAQmxGetPersistedScaleAllowInteractiveEditing(scaleName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedScaleAllowInteractiveEditing,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),scaleName,data)
 end
 
-function DAQmxGetPersistedScaleAllowInteractiveDeletion(scaleName::Ptr{Uint8},data::Ptr{bool32})
-    ccall((:DAQmxGetPersistedScaleAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{Uint8},Ptr{bool32}),scaleName,data)
+function DAQmxGetPersistedScaleAllowInteractiveDeletion(scaleName::Ptr{UInt8},data::Ptr{bool32})
+    ccall((:DAQmxGetPersistedScaleAllowInteractiveDeletion,NIDAQmx),int32,(Ptr{UInt8},Ptr{bool32}),scaleName,data)
 end
 
 function DAQmxGetSampClkTimingResponseMode(taskHandle::TaskHandle,data::Ptr{int32})

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -1,8 +1,9 @@
 function devices()
-    sz = GetSysDevNames(convert(Ptr{Uint8},C_NULL), uint32(0))
-    data=zeros(Uint8,sz)
-    catch_error(GetSysDevNames(convert(Ptr{Uint8},data), uint32(sz)))
-    map((x)->convert(ASCIIString,x), split(chop(string(char(data)...)),", "))
+    sz = GetSysDevNames(convert(Ptr{UInt8},C_NULL), UInt32(0))
+    data=zeros(UInt8,sz)
+    catch_error(GetSysDevNames(pointer(data), UInt32(sz)))
+    res = map((x)->convert(ASCIIString,x), split(chop(string(map(Char, data)...)),", "))
+    res = res[res .!= ""]
 end
 
 for (jfunction, cfunction) in (
@@ -13,10 +14,10 @@ for (jfunction, cfunction) in (
         (:counter_input_channels, GetDevCIPhysicalChans),
         (:counter_output_channels, GetDevCOPhysicalChans))
     @eval function $jfunction(device::ASCIIString)
-        sz = $cfunction(convert(Ptr{Uint8},device), convert(Ptr{Uint8},C_NULL), uint32(0))
-        data=zeros(Uint8,sz)
-        catch_error( $cfunction(convert(Ptr{Uint8},device), convert(Ptr{Uint8},data),
-                uint32(sz)) )
+        sz = $cfunction(pointer(device), convert(Ptr{UInt8},C_NULL), UInt32(0))
+        data=zeros(UInt8,sz)
+        catch_error( $cfunction(pointer(device), pointer(data),
+                UInt32(sz)) )
         map((x)->convert(ASCIIString,x), split(chop(string(char(data)...)),", "))
     end
 
@@ -31,10 +32,10 @@ for (jfunction, cfunction) in (
         (:analog_input_ranges, GetDevAIVoltageRngs),
         (:analog_output_ranges, GetDevAOVoltageRngs))
     @eval function $jfunction(device::ASCIIString)
-        sz = $cfunction(convert(Ptr{Uint8},device), convert(Ptr{Float64},C_NULL), uint32(0))
+        sz = $cfunction(pointer(device), convert(Ptr{Float64},C_NULL), UInt32(0))
         data=zeros(sz)
-        catch_error( $cfunction(convert(Ptr{Uint8},device), convert(Ptr{Float64},data),
-                uint32(sz)) )
+        catch_error( $cfunction(pointer(device),pointer(data),
+                UInt32(sz)) )
         reshape(data,(2,length(data)>>1))'
     end
 
@@ -48,19 +49,19 @@ end
 function channel_type(t::Task, channel::ASCIIString)
     val1 = Cint[0]
     catch_error(
-        GetChanType(t.th, convert(Ptr{Uint8},channel), convert(Ptr{Int32}, val1)) )
-      
+        GetChanType(t.th, pointer(channel), pointer(val1)) )
+
     val2 = Cint[0]
     if val1[1] == Val_AI
-        ret = GetAIMeasType(t.th, convert(Ptr{Uint8},channel), convert(Ptr{Int32}, val2))
+        ret = GetAIMeasType(t.th, pointer(channel), pointer(val2))
     elseif val1[1] == Val_AO
-        ret = GetAOOutputType(t.th, convert(Ptr{Uint8},channel), convert(Ptr{Int32}, val2))
+        ret = GetAOOutputType(t.th, pointer(channel), pointer(val2))
     elseif val1[1] == Val_DI || val1[1] == Val_DO
         return val1[1], nothing
     elseif val1[1] == Val_CI
-        ret = GetCIMeasType(t.th, convert(Ptr{Uint8},channel), convert(Ptr{Int32}, val2))
+        ret = GetCIMeasType(t.th, pointer(channel), pointer(val2))
     elseif val1[1] == Val_CO
-        ret = GetCOOutputType(t.th, convert(Ptr{Uint8},channel), convert(Ptr{Int32}, val2))
+        ret = GetCOOutputType(t.th, pointer(channel), pointer(val2))
     end
     catch_error(ret)
 
@@ -73,39 +74,44 @@ function getproperties_guts(args, suffix::ASCIIString, warning::Bool)
     local data
     local ret
     for sym in names(NIDAQ,true)
-        eval(:(typeof($sym)!=Function)) && continue
+        #isdefined(sym)||continue
+        eval(:(typeof(NIDAQ.$sym)!=Function)) && continue
         if string(sym)[1:min(end,8+length(suffix))]=="DAQmxGet"*suffix
             cfunction = getfield(NIDAQ, sym)
             signature = cfunction.env.defs.sig
             try
-                basetype = eval(parse(string(signature[1+length(args)])[5:end-1]))
-                if length(signature)==1+length(args)
+                #basetype = eval(parse(string(signature[1+length(args)])[5:end-1]))
+                #basetype = eval(parse(string(signature.types[1+length(args)])[5:end-1]))
+                basetype = eltype(signature.types[1+length(args)])
+                if length(signature.types)==1+length(args)
                     data = Array(basetype,1)
-                    ret = cfunction(args..., convert(Ptr{basetype},data))
+                    ret = cfunction(args..., pointer(data))
                     data = data[1]
                 else
-                    sz = cfunction(args..., convert(Ptr{basetype},C_NULL), convert(Uint32,0))
+                    sz = cfunction(args..., convert(Ptr{basetype},C_NULL), convert(UInt32,0))
                     if sz<0
                       ret=sz
                       throw()
                     end
                     data = zeros(basetype,sz)
-                    ret = cfunction(args..., convert(Ptr{basetype},data), convert(Uint32,sz))
+                    ret = cfunction(args..., pointer(data), convert(UInt32,sz))
                 end
                 if ret!=0
                     throw()
                 elseif basetype == Bool32
-                    data = reinterpret(Uint32, data) != 0
+                    data = reinterpret(UInt32, data) != 0
                 elseif basetype == Int32
                     try
                         data = map((x)->signed_constants[x], data)
                     end
-                elseif basetype == Uint32
+                elseif basetype == UInt32
                     try
                         data = map((x)->unsigned_constants[x], data)
                     end
-                elseif basetype == Uint8
-                    data = chop(string(char(data)...))
+                elseif basetype == UInt8
+                    #data = chop(string(char(data)...))
+                    #data = chop(string(map(Char, data)...))
+                    data = chop(ascii(data))
                     if search(data,',')>0
                         data = split(data,", ")
                     end
@@ -126,7 +132,7 @@ function getproperties_guts(args, suffix::ASCIIString, warning::Bool)
             catch
                 settable=false
             end
-            ret_val[string(cfunction)[9+length(suffix):end]] = (data, settable)
+            ret_val[string(cfunction)[6+9+length(suffix):end]] = (data, settable)
         end
     end
     ret_val
@@ -137,7 +143,7 @@ function getproperties(; warning=false)
 end
 
 function getproperties(device::ASCIIString; warning=false)
-    getproperties_guts((convert(Ptr{Uint8},device),), "Dev", warning)
+    getproperties_guts((pointer(device),), "Dev", warning)
 end
 
 function getproperties(t::Task; warning=false)
@@ -152,14 +158,14 @@ function getproperties(t::Task, channel::ASCIIString; warning=false)
     kind = channel_types[ find(channel_type(t, channel)[1] .==
             map((x)->getfield(NIDAQ,symbol(x)), channel_types))[1]][end-1:end]
 
-    getproperties_guts((t.th, convert(Ptr{Uint8},channel)), kind, warning)
+    getproperties_guts((t.th, pointer(channel)), kind, warning)
 end
 
 function setproperty!(t::Task, channel::ASCIIString, property::ASCIIString, value)
     kind = channel_types[ find(channel_type(t, channel)[1] .==
             map((x)->getfield(NIDAQ,symbol(x)), channel_types))[1]][end-1:end]
 
-    @eval ret = $(symbol("DAQmxSet"*kind*property))($t.th, convert(Ptr{Uint8},$channel), $value)
+    @eval ret = $(symbol("DAQmxSet"*kind*property))($t.th, pointer($channel), $value)
     catch_error(ret, "DAQmxSet$kind$property: ")
     nothing
 end

--- a/src/task.jl
+++ b/src/task.jl
@@ -10,7 +10,7 @@ end
 
 function task(name::ASCIIString)
     t = TaskHandle[0]
-    catch_error( DAQmxCreateTask(convert(Ptr{Uint8},name), convert(Ptr{TaskHandle},t)) )
+    catch_error( DAQmxCreateTask(pointer(name), pointer(t)) )
     t[1]
 end
 task() = task("")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,58 +1,86 @@
 using NIDAQ, Base.Test
 
+
+info("NIDAQ: Checking installation - no measurement hardware is needed for this section")
 @test typeof(getproperties()) == Dict{Any,Any}
-d = devices()[1]
-@test typeof(getproperties(d)) == Dict{Any,Any}
+@test haskey(getproperties(), "NIDAQMajorVersion")
+d = devices()
+device_available = false
+if length(d) == 0
+    info("NIDAQ: no measurement HW found, skipping rest of the test suite")
+else
+    d=d[1]
+    info("NIDAQ: found at least one measurement HW: $(d)")
+    @test typeof(getproperties(d)) == Dict{Any,Any}
+    pr = getproperties(d)
+    device_available = true
+end
 
-t = analog_input(d*"/ai0")
-@test typeof(getproperties(t)) == Dict{Any,Any}
-@test typeof(getproperties(t,d*"/ai0")) == Dict{Any,Any}
-@test typeof(t) == NIDAQ.AITask
-@test start(t) == nothing
-@test length(read(t, Float64, 3)) == 3
-@test stop(t) == nothing
-@test analog_input(t, d*"/ai1") == nothing
-@test start(t) == nothing
-@test length(read(t, Uint32, 6)) == 12
-@test stop(t) == nothing
-@test clear(t) == nothing
+if !(device_available && length(pr["AIPhysicalChans"]) == 0)
+    info("NIDAQ: measurement HW does not support any AIPhysicalChans, skipping part of the suite")
+else
+    t = analog_input(d*"/ai0")
+    @test typeof(getproperties(t)) == Dict{Any,Any}
+    @test typeof(getproperties(t,d*"/ai0")) == Dict{Any,Any}
+    @test typeof(t) == NIDAQ.AITask
+    @test start(t) == nothing
+    @test length(read(t, Float64, 3)) == 3
+    @test stop(t) == nothing
+    @test analog_input(t, d*"/ai1") == nothing
+    @test start(t) == nothing
+    @test length(read(t, UInt32, 6)) == 12
+    @test stop(t) == nothing
+    @test clear(t) == nothing
+end
 
-t = analog_output(d*"/ao0")
-@test typeof(t) == NIDAQ.AOTask
-@test start(t) == nothing
-@test write(t, rand(3)) == 3
-@test stop(t) == nothing
-@test analog_output(t, d*"/ao1") == nothing
-@test start(t) == nothing
-@test write(t, rand(Uint32,6,2)) == 6
-@test stop(t) == nothing
-@test clear(t) == nothing
+if !(device_available && length(pr["AOPhysicalChans"]) == 0)
+    info("NIDAQ: measurement HW does not support any AOPhysicalChans, skipping part of the suite")
+else
+    t = analog_output(d*"/ao0")
+    @test typeof(t) == NIDAQ.AOTask
+    @test start(t) == nothing
+    @test write(t, rand(3)) == 3
+    @test stop(t) == nothing
+    @test analog_output(t, d*"/ao1") == nothing
+    @test start(t) == nothing
+    @test write(t, rand(UInt32,6,2)) == 6
+    @test stop(t) == nothing
+    @test clear(t) == nothing
+end
 
-t = digital_input(d*"/Port0/Line0")
-@test typeof(t) == NIDAQ.DITask
-@test start(t) == nothing
-@test length(read(t, Uint32, 3)) == 3
-@test stop(t) == nothing
-@test digital_input(t, d*"/Port0/Line1") == nothing
-@test start(t) == nothing
-@test length(read(t, Uint8, 6)) == 12
-@test stop(t) == nothing
-@test clear(t) == nothing
+if !(device_available && length(pr["DILines"]) == 0)
+    info("NIDAQ: measurement HW does not support DILines, skipping part of the suite")
+else
+    t = digital_input(d*"/Port0/Line0")
+    @test typeof(t) == NIDAQ.DITask
+    @test start(t) == nothing
+    @test length(read(t, UInt32, 3)) == 3
+    @test stop(t) == nothing
+    @test digital_input(t, d*"/Port0/Line1") == nothing
+    @test start(t) == nothing
+    @test length(read(t, UInt8, 6)) == 12
+    @test stop(t) == nothing
+    @test clear(t) == nothing
 
-t = digital_output(d*"/Port0/Line0")
-@test typeof(t) == NIDAQ.DOTask
-@test start(t) == nothing
-@test write(t, uint32([1,0,1,0,1,0])) == 6
-@test stop(t) == nothing
-@test digital_output(t, d*"/Port0/Line1") == nothing
-@test start(t) == nothing
-@test write(t, uint8([1 0; 0 0; 1 0; 0 1; 1 1; 0 1])) == 6
-@test stop(t) == nothing
-@test clear(t) == nothing
+    t = digital_output(d*"/Port0/Line0")
+    @test typeof(t) == NIDAQ.DOTask
+    @test start(t) == nothing
+    @test write(t, UInt32([1,0,1,0,1,0])) == 6
+    @test stop(t) == nothing
+    @test digital_output(t, d*"/Port0/Line1") == nothing
+    @test start(t) == nothing
+    @test write(t, UInt8([1 0; 0 0; 1 0; 0 1; 1 1; 0 1])) == 6
+    @test stop(t) == nothing
+    @test clear(t) == nothing
+end
 
-t = generate_pulses(d*"/ctr0")
-@test typeof(t) == NIDAQ.COTask
-@test NIDAQ.CfgImplicitTiming(t.th, NIDAQ.Val_FiniteSamps, uint64(10)) == 0
-@test start(t) == nothing
-@test stop(t) == nothing
-@test clear(t) == nothing
+if !(device_available && length(pr["COPhysicalChans"]) == 0)
+    info("NIDAQ: measurement HW does not support COPhysicalChans, skipping part of the suite")
+else
+    t = generate_pulses(d*"/ctr0")
+    @test typeof(t) == NIDAQ.COTask
+    @test NIDAQ.CfgImplicitTiming(t.th, NIDAQ.Val_FiniteSamps, UInt64(10)) == 0
+    @test start(t) == nothing
+    @test stop(t) == nothing
+    @test clear(t) == nothing
+end


### PR DESCRIPTION
Uint->UInt, convert(Ptr{UInt32}, foo) -> pointer(foo).
*Changed tests to be runable even without measurement hardware
*tested on NIDAQmx 14.1 + NI USB 6008
