### PR TITLE
tests adapt to hardware functionality

### DIFF
--- a/src/properties.jl
+++ b/src/properties.jl
@@ -2,7 +2,9 @@ function devices()
     sz = GetSysDevNames(convert(Ptr{UInt8},C_NULL), UInt32(0))
     data=zeros(UInt8,sz)
     catch_error(GetSysDevNames(pointer(data), UInt32(sz)))
-    map((x)->convert(ASCIIString,x), split(chop(ascii(data)),", "))
+    devs = map((x)->convert(ASCIIString,x), split(chop(ascii(data)),", "))
+    devs[devs .!= ""]
+
 end
 
 for (jfunction, cfunction) in (
@@ -49,7 +51,7 @@ function channel_type(t::Task, channel::ASCIIString)
     val1 = Cint[0]
     catch_error(
         GetChanType(t.th, pointer(channel), pointer(val1)) )
-      
+
     val2 = Cint[0]
     if val1[1] == Val_AI
         ret = GetAIMeasType(t.th, pointer(channel), pointer(val2))

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -80,8 +80,8 @@ function getproperties_guts(args, suffix::ASCIIString, warning::Bool)
             cfunction = getfield(NIDAQ, sym)
             signature = cfunction.env.defs.sig
             try
-		basetype = eltype(signature.types[1+length(args)])
-		if length(signature.types)==1+length(args)
+		        basetype = eltype(signature.types[1+length(args)])
+		        if length(signature.types)==1+length(args)
                     data = Array(basetype,1)
                     ret = cfunction(args..., pointer(data))
                     data = data[1]
@@ -110,7 +110,12 @@ function getproperties_guts(args, suffix::ASCIIString, warning::Bool)
                     data = chop(ascii(data))
                     if search(data,',')>0
                         data = split(data,", ")
+                    else
+                        if data == ""
+                            data = ASCIIString[]
+                        end
                     end
+
                 end
             catch
                 if warning

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,66 +1,85 @@
 using NIDAQ, Base.Test
 
+info("NIDAQ: Checking installation - no measurement hardware is needed for this section")
 @test typeof(getproperties()) == Dict{ASCIIString,Tuple{Any,Bool}}
-d = devices()[1]
-@test typeof(getproperties(d)) == Dict{ASCIIString,Tuple{Any,Bool}}
-@test typeof(analog_input_channels()) == Vector{ASCIIString}
-@test typeof(analog_output_channels()) == Vector{ASCIIString}
-@test typeof(digital_input_channels()) == Vector{ASCIIString}
-@test typeof(digital_output_channels()) == Vector{ASCIIString}
-@test typeof(counter_input_channels()) == Vector{ASCIIString}
-@test typeof(counter_output_channels()) == Vector{ASCIIString}
-@test typeof(analog_input_ranges()) == Matrix{Float64}
-@test typeof(analog_output_ranges()) == Matrix{Float64}
+@test haskey(getproperties(), "NIDAQMajorVersion")
+d = devices()
+device_available = false
+if length(d) == 0
+    info("NIDAQ: no measurement HW found, skipping rest of the test suite")
+else
+    d=d[1]
+    info("NIDAQ: found at least one measurement HW: $(d)")
+    @test typeof(getproperties(d)) == Dict{ASCIIString,Tuple{Any,Bool}}
+    pr = getproperties(d)
+    device_available = true
+end
 
-t = analog_input(d*"/ai0")
-@test typeof(getproperties(t)) == Dict{ASCIIString,Tuple{Any,Bool}}
-@test typeof(getproperties(t,d*"/ai0")) == Dict{ASCIIString,Tuple{Any,Bool}}
-@test typeof(t) == NIDAQ.AITask
-@test start(t) == nothing
-@test length(read(t, Float64, 3)) == 3
-@test stop(t) == nothing
-@test analog_input(t, d*"/ai1") == nothing
-@test start(t) == nothing
-@test length(read(t, UInt32, 6)) == 12
-@test stop(t) == nothing
-@test clear(t) == nothing
+if !(device_available && length(pr["AIPhysicalChans"]) == 0)
+    info("NIDAQ: measurement HW does not support any AIPhysicalChans, skipping part of the suite")
+else
+    t = analog_input(d*"/ai0")
+    @test typeof(getproperties(t)) == Dict{ASCIIString,Tuple{Any,Bool}}
+    @test typeof(getproperties(t,d*"/ai0")) == Dict{ASCIIString,Tuple{Any,Bool}}
+    @test typeof(t) == NIDAQ.AITask
+    @test start(t) == nothing
+    @test length(read(t, Float64, 3)) == 3
+    @test stop(t) == nothing
+    @test analog_input(t, d*"/ai1") == nothing
+    @test start(t) == nothing
+    @test length(read(t, UInt32, 6)) == 12
+    @test stop(t) == nothing
+    @test clear(t) == nothing
+end
 
-t = analog_output(d*"/ao0")
-@test typeof(t) == NIDAQ.AOTask
-@test start(t) == nothing
-@test write(t, rand(3)) == 3
-@test stop(t) == nothing
-@test analog_output(t, d*"/ao1") == nothing
-@test start(t) == nothing
-@test write(t, rand(UInt32,6,2)) == 6
-@test stop(t) == nothing
-@test clear(t) == nothing
+if !(device_available && length(pr["AOPhysicalChans"]) == 0)
+    info("NIDAQ: measurement HW does not support any AOPhysicalChans, skipping part of the suite")
+else
+    t = analog_output(d*"/ao0")
+    @test typeof(t) == NIDAQ.AOTask
+    @test start(t) == nothing
+    @test write(t, rand(3)) == 3
+    @test stop(t) == nothing
+    @test analog_output(t, d*"/ao1") == nothing
+    @test start(t) == nothing
+    @test write(t, rand(UInt32,6,2)) == 6
+    @test stop(t) == nothing
+    @test clear(t) == nothing
+end
 
-t = digital_input(d*"/Port0/Line0")
-@test typeof(t) == NIDAQ.DITask
-@test start(t) == nothing
-@test length(read(t, UInt32, 3)) == 3
-@test stop(t) == nothing
-@test digital_input(t, d*"/Port0/Line1") == nothing
-@test start(t) == nothing
-@test length(read(t, UInt8, 6)) == 12
-@test stop(t) == nothing
-@test clear(t) == nothing
+if !(device_available && length(pr["DILines"]) == 0)
+    info("NIDAQ: measurement HW does not support DILines, skipping part of the suite")
+else
+    t = digital_input(d*"/Port0/Line0")
+    @test typeof(t) == NIDAQ.DITask
+    @test start(t) == nothing
+    @test length(read(t, UInt32, 3)) == 3
+    @test stop(t) == nothing
+    @test digital_input(t, d*"/Port0/Line1") == nothing
+    @test start(t) == nothing
+    @test length(read(t, UInt8, 6)) == 12
+    @test stop(t) == nothing
+    @test clear(t) == nothing
 
-t = digital_output(d*"/Port0/Line0")
-@test typeof(t) == NIDAQ.DOTask
-@test start(t) == nothing
-@test write(t, round(UInt32,[1,0,1,0,1,0])) == 6
-@test stop(t) == nothing
-@test digital_output(t, d*"/Port0/Line1") == nothing
-@test start(t) == nothing
-@test write(t, round(UInt8,[1 0; 0 0; 1 0; 0 1; 1 1; 0 1])) == 6
-@test stop(t) == nothing
-@test clear(t) == nothing
+    t = digital_output(d*"/Port0/Line0")
+    @test typeof(t) == NIDAQ.DOTask
+    @test start(t) == nothing
+    @test write(t, UInt32([1,0,1,0,1,0])) == 6
+    @test stop(t) == nothing
+    @test digital_output(t, d*"/Port0/Line1") == nothing
+    @test start(t) == nothing
+    @test write(t, UInt8([1 0; 0 0; 1 0; 0 1; 1 1; 0 1])) == 6
+    @test stop(t) == nothing
+    @test clear(t) == nothing
+end
 
-t = generate_pulses(d*"/ctr0")
-@test typeof(t) == NIDAQ.COTask
-@test NIDAQ.CfgImplicitTiming(t.th, NIDAQ.Val_FiniteSamps, round(UInt64,10)) == 0
-@test start(t) == nothing
-@test stop(t) == nothing
-@test clear(t) == nothing
+if !(device_available && length(pr["COPhysicalChans"]) == 0)
+    info("NIDAQ: measurement HW does not support COPhysicalChans, skipping part of the suite")
+else
+    t = generate_pulses(d*"/ctr0")
+    @test typeof(t) == NIDAQ.COTask
+    @test NIDAQ.CfgImplicitTiming(t.th, NIDAQ.Val_FiniteSamps, UInt64(10)) == 0
+    @test start(t) == nothing
+    @test stop(t) == nothing
+    @test clear(t) == nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,16 +4,28 @@ info("NIDAQ: Checking installation - no measurement hardware is needed for this 
 @test typeof(getproperties()) == Dict{ASCIIString,Tuple{Any,Bool}}
 @test haskey(getproperties(), "NIDAQMajorVersion")
 d = devices()
-device_available = false
+
 if length(d) == 0
     info("NIDAQ: no measurement HW found, skipping rest of the test suite")
+    device_available = false
 else
     d=d[1]
     info("NIDAQ: found at least one measurement HW: $(d)")
     @test typeof(getproperties(d)) == Dict{ASCIIString,Tuple{Any,Bool}}
     pr = getproperties(d)
     device_available = true
+
+    @test typeof(getproperties(d)) == Dict{ASCIIString,Tuple{Any,Bool}}
+    @test typeof(analog_input_channels()) == Vector{ASCIIString}
+    @test typeof(analog_output_channels()) == Vector{ASCIIString}
+    @test typeof(digital_input_channels()) == Vector{ASCIIString}
+    @test typeof(digital_output_channels()) == Vector{ASCIIString}
+    @test typeof(counter_input_channels()) == Vector{ASCIIString}
+    @test typeof(counter_output_channels()) == Vector{ASCIIString}
+    @test typeof(analog_input_ranges()) == Matrix{Float64}
+    @test typeof(analog_output_ranges()) == Matrix{Float64}
 end
+
 
 if !(device_available && length(pr["AIPhysicalChans"][1]) > 0)
     info("NIDAQ: measurement HW does not support any AIPhysicalChans, skipping part of the suite")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ else
     device_available = true
 end
 
-if !(device_available && length(pr["AIPhysicalChans"]) == 0)
+if !(device_available && length(pr["AIPhysicalChans"][1]) > 0)
     info("NIDAQ: measurement HW does not support any AIPhysicalChans, skipping part of the suite")
 else
     t = analog_input(d*"/ai0")
@@ -32,7 +32,7 @@ else
     @test clear(t) == nothing
 end
 
-if !(device_available && length(pr["AOPhysicalChans"]) == 0)
+if !(device_available && length(pr["AOPhysicalChans"][1]) > 0)
     info("NIDAQ: measurement HW does not support any AOPhysicalChans, skipping part of the suite")
 else
     t = analog_output(d*"/ao0")
@@ -47,7 +47,7 @@ else
     @test clear(t) == nothing
 end
 
-if !(device_available && length(pr["DILines"]) == 0)
+if !(device_available && length(pr["DILines"][1]) > 0)
     info("NIDAQ: measurement HW does not support DILines, skipping part of the suite")
 else
     t = digital_input(d*"/Port0/Line0")
@@ -60,20 +60,23 @@ else
     @test length(read(t, UInt8, 6)) == 12
     @test stop(t) == nothing
     @test clear(t) == nothing
-
+end
+if !(device_available && length(pr["DOLines"][1]) > 0)
+    info("NIDAQ: measurement HW does not support DILines, skipping part of the suite")
+else
     t = digital_output(d*"/Port0/Line0")
     @test typeof(t) == NIDAQ.DOTask
     @test start(t) == nothing
-    @test write(t, UInt32([1,0,1,0,1,0])) == 6
+    @test write(t, round(UInt32, [1,0,1,0,1,0])) == 6
     @test stop(t) == nothing
     @test digital_output(t, d*"/Port0/Line1") == nothing
     @test start(t) == nothing
-    @test write(t, UInt8([1 0; 0 0; 1 0; 0 1; 1 1; 0 1])) == 6
+    @test write(t, round(UInt8, [1 0; 0 0; 1 0; 0 1; 1 1; 0 1])) == 6
     @test stop(t) == nothing
     @test clear(t) == nothing
 end
 
-if !(device_available && length(pr["COPhysicalChans"]) == 0)
+if !(device_available && length(pr["COPhysicalChans"][1]) > 0)
     info("NIDAQ: measurement HW does not support COPhysicalChans, skipping part of the suite")
 else
     t = generate_pulses(d*"/ctr0")


### PR DESCRIPTION
Tests adapt to the offered functionality of the attached measurement device, e.g. if analog-out is missing the relevant tests are skipped. 
Bugfix: if no device is present devices() returns empty array instead of [""].
