### PR TITLE
require julia 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.5
+julia 0.6

--- a/src/NIDAQ.jl
+++ b/src/NIDAQ.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
+__precompile__()
 
 """
 `NIDAQ.jl` provides an interface to NI-DAQmx--- National Instruments' driver
@@ -40,7 +40,7 @@ export counter_input_channels, counter_output_channels
 
 const NIDAQmx = "C:\\Windows\\System32\\nicaiu.dll"
 
-bitstype 32 Bool32 <: Integer
+primitive type Bool32<:Integer 32 end
 export Bool32
 
 try

--- a/src/analog.jl
+++ b/src/analog.jl
@@ -70,7 +70,7 @@ function read(t::AITask, precision::DataType, num_samples_per_chan::Integer = -1
     num_channels = getproperties(t)["NumChans"][1]
     num_samples_per_chan_read = Int32[0]
     buffer_size = num_samples_per_chan==-1 ? 1024 : num_samples_per_chan
-    data = Array(precision, buffer_size*num_channels)
+    data = Array{precision}(buffer_size*num_channels)
     catch_error( read_analog_cfunctions[precision](t.th,
         convert(Int32,num_samples_per_chan),
         1.0,

--- a/src/digital.jl
+++ b/src/digital.jl
@@ -40,7 +40,7 @@ function read(t::DITask, precision::DataType, num_samples_per_chan::Integer = -1
     num_channels = getproperties(t)["NumChans"][1]
     num_samples_per_chan_read = Int32[0]
     buffer_size = num_samples_per_chan==-1 ? 1024 : num_samples_per_chan
-    data = Array(precision, buffer_size*num_channels)
+    data = Array{precision}(buffer_size*num_channels)
     catch_error( read_digital_cfunctions[precision](t.th,
         convert(Int32,num_samples_per_chan),
         1.0,

--- a/src/task.jl
+++ b/src/task.jl
@@ -1,4 +1,4 @@
-abstract Task
+abstract type Task end
 
 for pre in ("AI", "AO", "DI", "DO", "CI", "CO")
   @eval type $(Symbol(pre*"Task")) <: Task

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,11 +106,11 @@ else
     t = digital_output(dev*"/Port0/Line0")
     @test typeof(t) == NIDAQ.DOTask
     @test start(t) == nothing
-    @test write(t, round(UInt32, [1,0,1,0,1,0])) == 6
+    @test write(t, round.(UInt32, [1,0,1,0,1,0])) == 6
     @test stop(t) == nothing
     @test digital_output(t, dev*"/Port0/Line1") == nothing
     @test start(t) == nothing
-    @test write(t, round(UInt8, [1 0; 0 0; 1 0; 0 1; 1 1; 0 1])) == 6
+    @test write(t, round.(UInt8, [1 0; 0 0; 1 0; 0 1; 1 1; 0 1])) == 6
     @test stop(t) == nothing
     @test NIDAQ.CfgSampClkTiming(t.th, convert(Ref{UInt8},b""), 100.0, NIDAQ.Val_Rising,
               NIDAQ.Val_FiniteSamps, UInt64(10)) == 0


### PR DESCRIPTION
I think this addresses most deprecation warnings when using Julia 0.6 with NIDAQmx v16.0.  (Keeps Julia 0.5 support).