### PR TITLE
Cjg/usb 6002

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,7 +135,7 @@ end
 end
 
 @testset "counter output" begin
-if length(props["COPhysicalChans"][1]) == 0
+if isempty(props["COPhysicalChans"][1][1])
     info("$dev does not support COPhysicalChans")
 else
     t = generate_pulses(dev*"/ctr0")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,12 +90,18 @@ else
     @test start(t) == nothing
     @test length(read(t, UInt8, 6)) == 12
     @test stop(t) == nothing
-    @test NIDAQ.CfgSampClkTiming(t.th, convert(Ref{UInt8},b""), 100.0, NIDAQ.Val_Rising,
+    rslt = Ref{UInt32}(0)
+    NIDAQ.DAQmxGetBufInputOnbrdBufSize(t.th, rslt)
+    if rslt[] != 0 #If the device supports buffered digital input
+        @test NIDAQ.CfgSampClkTiming(t.th, convert(Ref{UInt8},b""), 100.0, NIDAQ.Val_Rising,
               NIDAQ.Val_FiniteSamps, UInt64(10)) == 0
-    @test start(t) == nothing
-    @test length(read(t, UInt32)) == 20
-    @test stop(t) == nothing
-    @test clear(t) == nothing
+	@test start(t) == nothing
+	@test length(read(t, UInt32)) == 20
+	@test stop(t) == nothing
+	@test clear(t) == nothing
+    else
+        info("Device does not support clocked (buffered) digital input")
+    end
 end
 end
 
@@ -112,13 +118,19 @@ else
     @test start(t) == nothing
     @test write(t, round.(UInt8, [1 0; 0 0; 1 0; 0 1; 1 1; 0 1])) == 6
     @test stop(t) == nothing
-    @test NIDAQ.CfgSampClkTiming(t.th, convert(Ref{UInt8},b""), 100.0, NIDAQ.Val_Rising,
+    rslt = Ref{UInt32}(0)
+    NIDAQ.DAQmxGetBufOutputOnbrdBufSize(t.th, rslt)
+    if rslt[] != 0 #If the device supports buffered digital output
+        @test NIDAQ.CfgSampClkTiming(t.th, convert(Ref{UInt8},b""), 100.0, NIDAQ.Val_Rising,
               NIDAQ.Val_FiniteSamps, UInt64(10)) == 0
-    @test write(t, rand(UInt32,10,2)) == 10 
-    @test start(t) == nothing
-    @test NIDAQ.WaitUntilTaskDone(t.th,10.0) == 0
-    @test stop(t) == nothing
-    @test clear(t) == nothing
+        @test write(t, rand(UInt32,10,2)) == 10
+        @test start(t) == nothing
+        @test NIDAQ.WaitUntilTaskDone(t.th,10.0) == 0
+        @test stop(t) == nothing
+        @test clear(t) == nothing
+    else
+        info("Device does not support clocked (buffered) digital output")
+    end
 end
 end
 


### PR DESCRIPTION
Modifies the test script so that devices without buffered digital input / output and counter output can pass.