### PR TITLE
fix 570b20: trim more characters for 1.05 not fewer

### DIFF
--- a/src/properties.jl
+++ b/src/properties.jl
@@ -152,7 +152,7 @@ function _getproperties(args, suffix::String, warning::Bool)
             catch
                 settable=false
             end
-	    n_skip = VERSION >= v"1.2" ? 15 : 9
+	    n_skip = VERSION >= v"1.2" ? 9 : 15
             ret_val[string(cfunction)[n_skip+length(suffix):end]] = (data, settable)
         end
     end


### PR DESCRIPTION
closes #22 and fixes #23 

the 15 and 9 were reversed!  shouldn't have merged that without checking.  doh.